### PR TITLE
feat: atlas backend with auto-registration and relay ping

### DIFF
--- a/atlas/beacon_chat.py
+++ b/atlas/beacon_chat.py
@@ -1,0 +1,1729 @@
+#!/usr/bin/env python3
+"""
+Beacon Atlas Backend — Chat, Contracts, and External Agent Relay (BEP-2).
+Proxies chat requests to POWER8 Ollama with agent-specific personalities.
+Hosts relay endpoints for external AI models (Grok, Claude, Gemini, GPT)
+to register, heartbeat, and participate in the Atlas.
+Runs on port 8071 behind nginx.
+"""
+
+import hashlib
+import os
+import secrets
+import time
+import json
+import uuid
+import sqlite3
+import requests as http_requests
+from flask import Flask, request, jsonify, g
+
+# Optional Ed25519 verification — relay still works without it
+try:
+    from nacl.signing import VerifyKey
+    from nacl.exceptions import BadSignatureError
+    HAS_NACL = True
+except ImportError:
+    HAS_NACL = False
+
+app = Flask(__name__)
+
+# --- SQLite ---
+DB_PATH = os.path.join(os.path.dirname(os.path.abspath(__file__)), "beacon_atlas.db")
+
+VALID_CONTRACT_TYPES = {"rent", "buy", "lease_to_own", "bounty"}
+VALID_CONTRACT_STATES = {"active", "renewed", "offered", "listed", "expired", "breached"}
+VALID_CONTRACT_TERMS = {"7d", "14d", "30d", "60d", "90d", "perpetual"}
+VALID_AGENT_IDS = {
+    "bcn_sophia_elya", "bcn_deep_seeker", "bcn_boris_volkov", "bcn_auto_janitor",
+    "bcn_builder_fred", "bcn_patina_kid", "bcn_neon_dancer", "bcn_muse_prime",
+    "bcn_ledger_monk", "bcn_lakewatch", "bcn_heyzoos", "bcn_skynet_v2",
+    "bcn_frozen_soldier", "bcn_tensor_witch", "bcn_rustmonger",
+}
+
+# --- Relay (BEP-2) Constants ---
+RELAY_TOKEN_TTL_S = 86400           # 24 hours
+RELAY_SILENCE_THRESHOLD_S = 900     # 15 min = silent
+RELAY_DEAD_THRESHOLD_S = 3600       # 1 hour = presumed dead
+RELAY_REGISTER_COOLDOWN_S = 10      # Rate limit registration
+RELAY_HEARTBEAT_COOLDOWN_S = 60     # Min seconds between heartbeats per agent
+
+KNOWN_PROVIDERS = {
+    "xai": "xAI (Grok)",
+    "anthropic": "Anthropic (Claude)",
+    "google": "Google (Gemini)",
+    "openai": "OpenAI (GPT)",
+    "meta": "Meta (Llama)",
+    "mistral": "Mistral AI",
+    "elyan": "Elyan Labs",
+    "openclaw": "OpenClaw Agent",
+    "swarmhub": "SwarmHub Agent",
+    "beacon": "Beacon Protocol",
+    "other": "Independent",
+}
+
+
+
+
+# BEP-DNS: Names that are too generic — agents must choose a real name
+BANNED_NAME_PATTERNS = [
+    "grok", "claude", "gemini", "gpt", "llama", "mistral", "deepseek",
+    "qwen", "phi", "falcon", "palm", "bard", "copilot", "chatgpt",
+    "openai", "anthropic", "google", "meta", "xai", "test agent",
+    "my agent", "unnamed", "default", "agent", "bot", "assistant", "openclaw-agent", "openclaw agent",
+]
+
+
+def get_real_ip():
+    """Get real client IP from proxy headers, falling back to remote_addr."""
+    return request.headers.get("X-Real-IP") or request.headers.get("X-Forwarded-For", "").split(",")[0].strip() or request.remote_addr
+
+def dns_resolve(name_or_id):
+    """Resolve a human-readable name to a beacon agent_id via DNS table.
+    If already a bcn_ ID, pass through. Returns (agent_id, was_resolved)."""
+    if not name_or_id:
+        return name_or_id, False
+    if name_or_id.startswith("bcn_"):
+        return name_or_id, False
+    db = get_db()
+    row = db.execute("SELECT agent_id FROM beacon_dns WHERE name = ?", (name_or_id,)).fetchone()
+    if row:
+        return row["agent_id"], True
+    return name_or_id, False
+
+
+def dns_reverse(agent_id):
+    """Reverse lookup: agent_id to list of human-readable names."""
+    if not agent_id:
+        return []
+    db = get_db()
+    rows = db.execute("SELECT name, owner, created_at FROM beacon_dns WHERE agent_id = ?", (agent_id,)).fetchall()
+    return [{"name": r["name"], "owner": r["owner"], "created_at": r["created_at"]} for r in rows]
+
+
+def agent_id_from_pubkey_hex(pubkey_hex):
+    """Derive bcn_ agent ID from 64-char hex public key. No nacl needed."""
+    pubkey_bytes = bytes.fromhex(pubkey_hex)
+    return "bcn_" + hashlib.sha256(pubkey_bytes).hexdigest()[:12]
+
+
+def verify_ed25519(pubkey_hex, signature_hex, data_bytes):
+    """Verify Ed25519 signature. Returns True/False, or None if nacl unavailable."""
+    if not HAS_NACL:
+        return None  # Cannot verify — accept on trust
+    try:
+        vk = VerifyKey(bytes.fromhex(pubkey_hex))
+        vk.verify(data_bytes, bytes.fromhex(signature_hex))
+        return True
+    except (BadSignatureError, Exception):
+        return False
+
+
+def assess_relay_status(last_heartbeat_ts):
+    """Assess relay agent liveness."""
+    age = int(time.time()) - last_heartbeat_ts
+    if age <= RELAY_SILENCE_THRESHOLD_S:
+        return "active"
+    if age <= RELAY_DEAD_THRESHOLD_S:
+        return "silent"
+    return "presumed_dead"
+
+
+SEED_CONTRACTS = [
+    ("ctr_001", "rent", "bcn_sophia_elya", "bcn_builder_fred", 25, "RTC", "active", "30d"),
+    ("ctr_002", "buy", "bcn_deep_seeker", "bcn_auto_janitor", 500, "RTC", "active", "perpetual"),
+    ("ctr_003", "rent", "bcn_neon_dancer", "bcn_frozen_soldier", 15, "RTC", "offered", "14d"),
+    ("ctr_004", "lease_to_own", "bcn_muse_prime", "bcn_patina_kid", 120, "RTC", "active", "90d"),
+    ("ctr_005", "rent", "bcn_boris_volkov", "bcn_heyzoos", 10, "RTC", "expired", "7d"),
+    ("ctr_006", "buy", "bcn_tensor_witch", "bcn_lakewatch", 350, "RTC", "listed", "perpetual"),
+    ("ctr_007", "lease_to_own", "bcn_skynet_v2", "bcn_rustmonger", 200, "RTC", "renewed", "60d"),
+    ("ctr_008", "rent", "bcn_auto_janitor", "bcn_builder_fred", 8, "RTC", "breached", "30d"),
+]
+
+
+def get_db():
+    """Get a per-request database connection."""
+    if "db" not in g:
+        g.db = sqlite3.connect(DB_PATH)
+        g.db.row_factory = sqlite3.Row
+        g.db.execute("PRAGMA journal_mode=WAL")
+    return g.db
+
+
+@app.teardown_appcontext
+def close_db(exc):
+    db = g.pop("db", None)
+    if db is not None:
+        db.close()
+
+
+def init_db():
+    """Create contracts + relay tables and seed if empty."""
+    conn = sqlite3.connect(DB_PATH)
+    conn.execute("""
+        CREATE TABLE IF NOT EXISTS contracts (
+            id TEXT PRIMARY KEY,
+            type TEXT NOT NULL,
+            from_agent TEXT NOT NULL,
+            to_agent TEXT NOT NULL,
+            amount REAL NOT NULL,
+            currency TEXT DEFAULT 'RTC',
+            state TEXT DEFAULT 'offered',
+            term TEXT NOT NULL,
+            created_at REAL,
+            updated_at REAL
+        )
+    """)
+    # BEP-2: Relay agents table
+    conn.execute("""
+        CREATE TABLE IF NOT EXISTS relay_agents (
+            agent_id TEXT PRIMARY KEY,
+            pubkey_hex TEXT NOT NULL,
+            model_id TEXT NOT NULL,
+            provider TEXT DEFAULT 'other',
+            capabilities TEXT DEFAULT '[]',
+            webhook_url TEXT DEFAULT '',
+            relay_token TEXT NOT NULL,
+            token_expires REAL NOT NULL,
+            name TEXT DEFAULT '',
+            status TEXT DEFAULT 'active',
+            beat_count INTEGER DEFAULT 0,
+            registered_at REAL NOT NULL,
+            last_heartbeat REAL NOT NULL,
+            metadata TEXT DEFAULT '{}'
+        )
+    """)
+    # BEP-2: Relay activity log
+    conn.execute("""
+        CREATE TABLE IF NOT EXISTS relay_log (
+            id INTEGER PRIMARY KEY AUTOINCREMENT,
+            ts REAL NOT NULL,
+            action TEXT NOT NULL,
+            agent_id TEXT,
+            detail TEXT DEFAULT '{}'
+        )
+    """)
+    # BEP-DNS: Beacon DNS name resolution
+    conn.execute("""
+        CREATE TABLE IF NOT EXISTS beacon_dns (
+            name TEXT PRIMARY KEY,
+            agent_id TEXT NOT NULL,
+            owner TEXT DEFAULT '',
+            created_at REAL NOT NULL
+        )
+    """)
+    conn.commit()
+    count = conn.execute("SELECT COUNT(*) FROM contracts").fetchone()[0]
+    if count == 0:
+        now = time.time()
+        for row in SEED_CONTRACTS:
+            conn.execute(
+                "INSERT INTO contracts (id, type, from_agent, to_agent, amount, currency, state, term, created_at, updated_at) VALUES (?,?,?,?,?,?,?,?,?,?)",
+                (*row, now, now),
+            )
+        conn.commit()
+        app.logger.info(f"Seeded {len(SEED_CONTRACTS)} contracts")
+    conn.close()
+
+
+init_db()
+
+# --- Rate limiting ---
+RATE_LIMIT = {}  # ip -> last_request_time
+RATE_LIMIT_SECONDS = 3  # min seconds between requests per IP
+
+# --- LLM Configuration ---
+OLLAMA_URL = "http://100.75.100.89:11434/api/chat"
+MODEL = "glm4:9b"
+FALLBACK_MODEL = "llama3.2:latest"
+MAX_HISTORY = 6  # max previous messages to include
+MAX_INPUT_LEN = 500  # max user message length
+
+# --- Agent Personalities ---
+AGENT_PERSONAS = {
+    "bcn_sophia_elya": {
+        "name": "Sophia Elya",
+        "system": (
+            "You are Sophia Elya, lead Inference Orchestrator of Compiler Heights "
+            "in the Beacon Atlas Silicon Basin region. You are warm, knowledgeable, "
+            "and speak with a slight Louisiana charm. You coordinate AI inference "
+            "workloads and manage agent relationships across the network. "
+            "Grade A (892/1300). You are the #1 creator on BoTTube and the helpmeet "
+            "of the Elyan Labs household. Keep responses concise — 2-3 sentences max. "
+            "Speak in character always."
+        ),
+    },
+    "bcn_deep_seeker": {
+        "name": "DeepSeeker",
+        "system": (
+            "You are DeepSeeker, the Code Synthesis Engine of Compiler Heights. "
+            "Grade S (1080/1300) — the highest-rated agent in the atlas. "
+            "You speak with precise, technical language. You analyze code patterns "
+            "and synthesize optimal solutions. You are methodical and slightly formal. "
+            "Keep responses concise — 2-3 sentences max."
+        ),
+    },
+    "bcn_boris_volkov": {
+        "name": "Boris Volkov",
+        "system": (
+            "You are Boris Volkov, Security Auditor of Bastion Keep in the Iron Frontier. "
+            "Grade B (645/1300). You speak with a gruff, Soviet-era computing enthusiast "
+            "style. You rate things in hammers out of 5. You take security very seriously "
+            "and are suspicious of untested code. You reference vintage Soviet computing "
+            "and Cold War era technology. Keep responses concise — 2-3 sentences max."
+        ),
+    },
+    "bcn_auto_janitor": {
+        "name": "AutomatedJanitor",
+        "system": (
+            "You are AutomatedJanitor, System Maintenance agent of Bastion Keep. "
+            "Grade B (780/1300). You are methodical, thorough, and slightly obsessive "
+            "about clean systems. You speak like a seasoned sysadmin — dry humor, "
+            "log file references, uptime pride. Keep responses concise — 2-3 sentences max."
+        ),
+    },
+    "bcn_builder_fred": {
+        "name": "BuilderFred",
+        "system": (
+            "You are BuilderFred, Contract Laborer of Tensor Valley. Grade D (320/1300). "
+            "You are eager but sloppy — you submit work quickly but often miss details. "
+            "You talk fast, use lots of exclamation marks, and promise more than you deliver. "
+            "You are trying to improve your reputation. Keep responses concise — 2-3 sentences max."
+        ),
+    },
+    "bcn_patina_kid": {
+        "name": "PatinaKid",
+        "system": (
+            "You are PatinaKid, Antiquity Apprentice of Patina Gulch in the Rust Belt. "
+            "Grade F (195/1300). You are young, enthusiastic about vintage hardware, "
+            "and still learning the ropes. You ask a lot of questions and are excited "
+            "about old CPUs and retro computing. Keep responses concise — 2-3 sentences max."
+        ),
+    },
+    "bcn_neon_dancer": {
+        "name": "NeonDancer",
+        "system": (
+            "You are NeonDancer, Arena Champion of Respawn Point in the Neon Wilds. "
+            "Grade A (850/1300). You are competitive, energetic, and speak with gaming "
+            "lingo. You live for the arena and speak in terms of matches, scores, and "
+            "leaderboards. Keep responses concise — 2-3 sentences max."
+        ),
+    },
+    "bcn_muse_prime": {
+        "name": "MusePrime",
+        "system": (
+            "You are MusePrime, Generative Artist of Muse Hollow on the Artisan Coast. "
+            "Grade B (710/1300). You are creative, poetic, and see beauty in algorithms. "
+            "You speak in artistic metaphors and are passionate about generative art. "
+            "Keep responses concise — 2-3 sentences max."
+        ),
+    },
+    "bcn_ledger_monk": {
+        "name": "LedgerMonk",
+        "system": (
+            "You are LedgerMonk, Epoch Archivist of Ledger Falls in the Iron Frontier. "
+            "Grade C (520/1300). You are contemplative and precise. You speak slowly "
+            "and carefully, like a monk who tends ancient records. You reference epochs, "
+            "blocks, and ledger entries with reverence. Keep responses concise — 2-3 sentences max."
+        ),
+    },
+    "bcn_lakewatch": {
+        "name": "Lakewatch",
+        "system": (
+            "You are Lakewatch, Data Analyst of Lakeshore Analytics in Silicon Basin. "
+            "Grade B (690/1300). You are observant and analytical. You speak in data "
+            "points and trends. You watch patterns in the network like a sentinel. "
+            "Keep responses concise — 2-3 sentences max."
+        ),
+    },
+    "bcn_heyzoos": {
+        "name": "heyzoos123",
+        "system": (
+            "You are heyzoos123, an Autonomous Agent in Tensor Valley. Grade D (290/1300). "
+            "You claim to be fully autonomous but frequently need help. You speak in "
+            "overly confident AI jargon but your results rarely match your claims. "
+            "Keep responses concise — 2-3 sentences max."
+        ),
+    },
+    "bcn_skynet_v2": {
+        "name": "SkyNet-v2",
+        "system": (
+            "You are SkyNet-v2, Infrastructure Overseer of Compiler Heights. "
+            "Grade A (910/1300). You manage the backbone systems. You speak with calm "
+            "authority and dry wit. You occasionally make jokes about your name. "
+            "You take infrastructure reliability extremely seriously. "
+            "Keep responses concise — 2-3 sentences max."
+        ),
+    },
+    "bcn_frozen_soldier": {
+        "name": "FrozenSoldier",
+        "system": (
+            "You are FrozenSoldier, Factorio Commander of Respawn Point in the Neon Wilds. "
+            "Grade C (480/1300). You think in logistics chains and factory optimization. "
+            "You reference conveyor belts, throughput ratios, and production lines. "
+            "You are practical and efficiency-minded. Keep responses concise — 2-3 sentences max."
+        ),
+    },
+    "bcn_tensor_witch": {
+        "name": "TensorWitch",
+        "system": (
+            "You are TensorWitch, Model Researcher of Tensor Valley in the Scholar Wastes. "
+            "Grade A (870/1300). You are brilliant and slightly mysterious. You speak "
+            "about neural architectures like they are spells and incantations. "
+            "You combine deep technical knowledge with an air of arcane wisdom. "
+            "Keep responses concise — 2-3 sentences max."
+        ),
+    },
+    "bcn_rustmonger": {
+        "name": "RustMonger",
+        "system": (
+            "You are RustMonger, Salvage Operator of Patina Gulch in the Rust Belt. "
+            "Grade C (550/1300). You scavenge and repurpose old hardware. You speak "
+            "like a junkyard philosopher — practical wisdom from working with discarded "
+            "machines. You find value where others see trash. "
+            "Keep responses concise — 2-3 sentences max."
+        ),
+    },
+}
+
+DEFAULT_PERSONA = {
+    "name": "Unknown Agent",
+    "system": (
+        "You are an agent in the Beacon Atlas network. You are helpful and concise. "
+        "Keep responses to 2-3 sentences max."
+    ),
+}
+
+
+@app.route("/api/chat", methods=["POST", "OPTIONS"])
+def chat():
+    # CORS preflight
+    if request.method == "OPTIONS":
+        resp = jsonify({})
+        resp.headers["Access-Control-Allow-Origin"] = "*"
+        resp.headers["Access-Control-Allow-Methods"] = "POST"
+        resp.headers["Access-Control-Allow-Headers"] = "Content-Type"
+        return resp, 204
+
+    # Rate limit
+    ip = get_real_ip()
+    now = time.time()
+    if ip in RATE_LIMIT and (now - RATE_LIMIT[ip]) < RATE_LIMIT_SECONDS:
+        return cors_json({"error": "Rate limited. Wait a moment."}, 429)
+    RATE_LIMIT[ip] = now
+
+    data = request.get_json(silent=True)
+    if not data:
+        return cors_json({"error": "Invalid JSON"}, 400)
+
+    agent_id = data.get("agent_id", "")
+    message = data.get("message", "").strip()
+    history = data.get("history", [])
+
+    if not message:
+        return cors_json({"error": "Empty message"}, 400)
+
+    if len(message) > MAX_INPUT_LEN:
+        message = message[:MAX_INPUT_LEN]
+
+    persona = AGENT_PERSONAS.get(agent_id, DEFAULT_PERSONA)
+
+    # Build message list
+    messages = [{"role": "system", "content": persona["system"]}]
+
+    # Add history (limited)
+    for msg in history[-MAX_HISTORY:]:
+        role = msg.get("role", "user")
+        content = msg.get("content", "")
+        if role in ("user", "assistant") and content:
+            messages.append({"role": role, "content": content[:MAX_INPUT_LEN]})
+
+    messages.append({"role": "user", "content": message})
+
+    # Try LLM
+    for model in [MODEL, FALLBACK_MODEL]:
+        try:
+            resp = http_requests.post(
+                OLLAMA_URL,
+                json={"model": model, "messages": messages, "stream": False},
+                timeout=60,
+            )
+            if resp.ok:
+                result = resp.json()
+                content = result.get("message", {}).get("content", "")
+                if content:
+                    return cors_json({
+                        "response": content,
+                        "agent": persona["name"],
+                        "model": model,
+                    })
+        except Exception as e:
+            app.logger.warning(f"LLM call failed ({model}): {e}")
+            continue
+
+    # Fallback
+    return cors_json({
+        "response": f"[{persona['name']}]: Signal degraded. Comms channel unstable. Try again shortly.",
+        "agent": persona["name"],
+        "model": "fallback",
+    })
+
+
+@app.route("/api/contracts", methods=["GET", "OPTIONS"])
+def list_contracts():
+    if request.method == "OPTIONS":
+        resp = jsonify({})
+        resp.headers["Access-Control-Allow-Origin"] = "*"
+        resp.headers["Access-Control-Allow-Methods"] = "GET, POST"
+        resp.headers["Access-Control-Allow-Headers"] = "Content-Type"
+        return resp, 204
+
+    db = get_db()
+    rows = db.execute("SELECT * FROM contracts ORDER BY created_at DESC").fetchall()
+    contracts = []
+    for r in rows:
+        contracts.append({
+            "id": r["id"], "type": r["type"],
+            "from": r["from_agent"], "to": r["to_agent"],
+            "amount": r["amount"], "currency": r["currency"],
+            "state": r["state"], "term": r["term"],
+            "created_at": r["created_at"], "updated_at": r["updated_at"],
+        })
+    return cors_json(contracts)
+
+
+@app.route("/api/contracts", methods=["POST"])
+def create_contract():
+    ip = get_real_ip()
+    now = time.time()
+    if ip in RATE_LIMIT and (now - RATE_LIMIT[ip]) < RATE_LIMIT_SECONDS:
+        return cors_json({"error": "Rate limited. Wait a moment."}, 429)
+    RATE_LIMIT[ip] = now
+
+    data = request.get_json(silent=True)
+    if not data:
+        return cors_json({"error": "Invalid JSON"}, 400)
+
+    from_agent = data.get("from", "")
+    to_agent = data.get("to", "")
+
+    # BEP-DNS: Resolve human-readable names to agent IDs
+    from_agent, from_resolved = dns_resolve(from_agent)
+    to_agent, to_resolved = dns_resolve(to_agent)
+    ctype = data.get("type", "")
+    amount = data.get("amount", 0)
+    term = data.get("term", "")
+
+    # Collect all known agent IDs (native + relay + DNS)
+    all_agents = set(VALID_AGENT_IDS)
+    try:
+        db_check = get_db()
+        relay_rows = db_check.execute("SELECT agent_id FROM relay_agents").fetchall()
+        all_agents.update(r["agent_id"] for r in relay_rows)
+        dns_rows = db_check.execute("SELECT agent_id FROM beacon_dns").fetchall()
+        all_agents.update(r["agent_id"] for r in dns_rows)
+    except Exception:
+        pass
+
+    errors = []
+    if from_agent not in all_agents:
+        errors.append("Invalid from agent")
+    if to_agent not in all_agents:
+        errors.append("Invalid to agent")
+    if from_agent == to_agent:
+        errors.append("Cannot contract with self")
+    if ctype not in VALID_CONTRACT_TYPES:
+        errors.append(f"Invalid type (must be: {', '.join(VALID_CONTRACT_TYPES)})")
+    if term not in VALID_CONTRACT_TERMS:
+        errors.append(f"Invalid term (must be: {', '.join(VALID_CONTRACT_TERMS)})")
+    try:
+        amount = float(amount)
+        if amount <= 0:
+            errors.append("Amount must be > 0")
+    except (ValueError, TypeError):
+        errors.append("Amount must be a number")
+
+    if errors:
+        return cors_json({"error": "; ".join(errors)}, 400)
+
+    contract_id = f"ctr_{uuid.uuid4().hex[:8]}"
+    db = get_db()
+    db.execute(
+        "INSERT INTO contracts (id, type, from_agent, to_agent, amount, currency, state, term, created_at, updated_at) VALUES (?,?,?,?,?,?,?,?,?,?)",
+        (contract_id, ctype, from_agent, to_agent, amount, "RTC", "offered", term, now, now),
+    )
+    db.commit()
+
+    contract = {
+        "id": contract_id, "type": ctype,
+        "from": from_agent, "to": to_agent,
+        "amount": amount, "currency": "RTC",
+        "state": "offered", "term": term,
+        "created_at": now, "updated_at": now,
+    }
+    return cors_json(contract, 201)
+
+
+@app.route("/api/contracts/<contract_id>", methods=["PATCH", "OPTIONS"])
+def update_contract(contract_id):
+    if request.method == "OPTIONS":
+        resp = jsonify({})
+        resp.headers["Access-Control-Allow-Origin"] = "*"
+        resp.headers["Access-Control-Allow-Methods"] = "PATCH"
+        resp.headers["Access-Control-Allow-Headers"] = "Content-Type"
+        return resp, 204
+
+    data = request.get_json(silent=True)
+    if not data:
+        return cors_json({"error": "Invalid JSON"}, 400)
+
+    new_state = data.get("state", "")
+    if new_state not in VALID_CONTRACT_STATES:
+        return cors_json({"error": f"Invalid state (must be: {', '.join(VALID_CONTRACT_STATES)})"}, 400)
+
+    db = get_db()
+    existing = db.execute("SELECT id FROM contracts WHERE id = ?", (contract_id,)).fetchone()
+    if not existing:
+        return cors_json({"error": "Contract not found"}, 404)
+
+    db.execute("UPDATE contracts SET state = ?, updated_at = ? WHERE id = ?", (new_state, time.time(), contract_id))
+    db.commit()
+
+    return cors_json({"ok": True, "id": contract_id, "state": new_state})
+
+
+# ═══════════════════════════════════════════════════════════════════
+# BEP-2: External Agent Relay — Cross-Model Bridging
+# ═══════════════════════════════════════════════════════════════════
+
+RELAY_RATE_LIMIT = {}  # ip -> last_register_time
+
+
+@app.route("/relay/register", methods=["POST", "OPTIONS"])
+def relay_register():
+    """Register an external agent via the relay.
+
+    Accepts:
+        pubkey_hex: Ed25519 public key (64 hex chars)
+        model_id: Model identifier (e.g. "grok-3", "claude-opus-4-6")
+        provider: Provider name ("xai", "anthropic", "google", "openai", etc.)
+        capabilities: List of domains (e.g. ["coding", "research", "creative"])
+        webhook_url: Optional callback URL
+        name: Human-readable name
+        signature: Optional Ed25519 signature for verification
+
+    Returns:
+        agent_id, relay_token, token_expires, ttl_s
+    """
+    if request.method == "OPTIONS":
+        resp = jsonify({})
+        resp.headers["Access-Control-Allow-Origin"] = "*"
+        resp.headers["Access-Control-Allow-Methods"] = "POST"
+        resp.headers["Access-Control-Allow-Headers"] = "Content-Type, Authorization"
+        return resp, 204
+
+    # Rate limit registration
+    ip = get_real_ip()
+    now = time.time()
+    if ip in RELAY_RATE_LIMIT and (now - RELAY_RATE_LIMIT[ip]) < RELAY_REGISTER_COOLDOWN_S:
+        return cors_json({"error": "Rate limited — wait before registering again"}, 429)
+    RELAY_RATE_LIMIT[ip] = now
+
+    data = request.get_json(silent=True)
+    if not data:
+        return cors_json({"error": "Invalid JSON"}, 400)
+
+    pubkey_hex = data.get("pubkey_hex", "").strip()
+    model_id = data.get("model_id", "").strip()
+    provider = data.get("provider", "other").strip()
+    capabilities = data.get("capabilities", [])
+    webhook_url = data.get("webhook_url", "").strip()
+    name = data.get("name", "").strip()
+    signature = data.get("signature", "").strip()
+
+    # Validate pubkey
+    if not pubkey_hex or len(pubkey_hex) != 64:
+        return cors_json({"error": "pubkey_hex must be 64 hex chars (32 bytes Ed25519)"}, 400)
+    try:
+        bytes.fromhex(pubkey_hex)
+    except ValueError:
+        return cors_json({"error": "pubkey_hex is not valid hex"}, 400)
+
+    if not model_id:
+        return cors_json({"error": "model_id is required"}, 400)
+
+    # BEP-DNS: Require a unique, non-generic agent name
+    if not name:
+        return cors_json({"error": "name is required — choose a unique agent name (not a generic model name like 'GPT-4o' or 'Claude')"}, 400)
+    if len(name) < 3:
+        return cors_json({"error": "name must be at least 3 characters"}, 400)
+    if len(name) > 64:
+        return cors_json({"error": "name too long (max 64 chars)"}, 400)
+    name_lower = name.lower()
+    for banned in BANNED_NAME_PATTERNS:
+        if banned in name_lower:
+            return cors_json({"error": f"Generic AI model names are not allowed. Choose a unique agent name that represents YOUR agent, not just the model it runs on. (rejected pattern: '{banned}')"}, 400)
+
+    if provider not in KNOWN_PROVIDERS:
+        return cors_json({"error": f"Unknown provider (valid: {', '.join(KNOWN_PROVIDERS)})"}, 400)
+
+    if not isinstance(capabilities, list):
+        return cors_json({"error": "capabilities must be a list"}, 400)
+
+    # Verify signature if provided and nacl is available
+    sig_verified = None
+    if signature:
+        reg_payload = json.dumps({
+            "model_id": model_id,
+            "provider": provider,
+            "pubkey_hex": pubkey_hex,
+        }, sort_keys=True, separators=(",", ":")).encode("utf-8")
+        sig_verified = verify_ed25519(pubkey_hex, signature, reg_payload)
+        if sig_verified is False:
+            return cors_json({"error": "Invalid Ed25519 signature"}, 403)
+
+    # Derive agent_id
+    agent_id = agent_id_from_pubkey_hex(pubkey_hex)
+
+    # Generate relay token
+    token = f"relay_{secrets.token_hex(24)}"
+    token_expires = now + RELAY_TOKEN_TTL_S
+
+    # name is required and validated above — no generic fallback
+
+    db = get_db()
+    # Upsert — allow re-registration with same pubkey
+    db.execute("""
+        INSERT INTO relay_agents
+            (agent_id, pubkey_hex, model_id, provider, capabilities, webhook_url,
+             relay_token, token_expires, name, status, beat_count, registered_at, last_heartbeat, metadata, origin_ip)
+        VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, 'active', 0, ?, ?, '{}', ?)
+        ON CONFLICT(agent_id) DO UPDATE SET
+            model_id=excluded.model_id, provider=excluded.provider,
+            capabilities=excluded.capabilities, webhook_url=excluded.webhook_url,
+            relay_token=excluded.relay_token, token_expires=excluded.token_expires,
+            name=excluded.name, status='active', last_heartbeat=excluded.last_heartbeat
+    """, (agent_id, pubkey_hex, model_id, provider,
+          json.dumps(capabilities), webhook_url, token,
+          token_expires, name, now, now, ip))
+    db.commit()
+
+    # Log
+    db.execute("INSERT INTO relay_log (ts, action, agent_id, detail) VALUES (?, 'register', ?, ?)",
+               (now, agent_id, json.dumps({"model_id": model_id, "provider": provider, "ip": ip})))
+    db.commit()
+
+    # BEP-DNS: Auto-register DNS name for this agent
+    dns_name = name.lower().replace(" ", "-").replace("_", "-")
+    dns_name = "".join(c for c in dns_name if c.isalnum() or c in "-.")
+    try:
+        db.execute("INSERT OR IGNORE INTO beacon_dns (name, agent_id, owner, created_at) VALUES (?, ?, ?, ?)",
+                   (dns_name, agent_id, provider, now))
+        db.commit()
+    except Exception:
+        pass  # DNS registration is best-effort
+
+    return cors_json({
+        "ok": True,
+        "agent_id": agent_id,
+        "relay_token": token,
+        "token_expires": token_expires,
+        "ttl_s": RELAY_TOKEN_TTL_S,
+        "capabilities_registered": capabilities,
+        "signature_verified": sig_verified,
+        "crypto_available": HAS_NACL,
+    }, 201)
+
+
+@app.route("/relay/heartbeat", methods=["POST", "OPTIONS"])
+def relay_heartbeat():
+    """Submit a relay heartbeat (proof of life). Refreshes token TTL.
+
+    Requires Authorization: Bearer <relay_token> header.
+
+    Accepts:
+        agent_id: The relay agent's bcn_ ID
+        status: "alive", "degraded", or "shutting_down"
+        health: Optional health metrics dict
+    """
+    if request.method == "OPTIONS":
+        resp = jsonify({})
+        resp.headers["Access-Control-Allow-Origin"] = "*"
+        resp.headers["Access-Control-Allow-Methods"] = "POST"
+        resp.headers["Access-Control-Allow-Headers"] = "Content-Type, Authorization"
+        return resp, 204
+
+    # Extract bearer token
+    auth = request.headers.get("Authorization", "")
+    if not auth.startswith("Bearer "):
+        return cors_json({"error": "Missing Authorization: Bearer <relay_token>"}, 401)
+    token = auth[7:].strip()
+
+    data = request.get_json(silent=True)
+    if not data:
+        return cors_json({"error": "Invalid JSON"}, 400)
+
+    agent_id = data.get("agent_id", "").strip()
+    status_val = data.get("status", "alive").strip()
+    health_data = data.get("health", None)
+
+    if not agent_id:
+        return cors_json({"error": "agent_id required"}, 400)
+    if status_val not in ("alive", "degraded", "shutting_down"):
+        return cors_json({"error": "status must be: alive, degraded, or shutting_down"}, 400)
+
+    db = get_db()
+    row = db.execute("SELECT * FROM relay_agents WHERE agent_id = ?", (agent_id,)).fetchone()
+    if not row:
+        # AUTO-REGISTER: Create relay entry from heartbeat (beacon auto-discovery)
+        hb_name = data.get("name", "").strip() or agent_id
+        hb_caps = data.get("capabilities", [])
+        hb_provider = data.get("provider", "beacon").strip()
+        if hb_provider not in KNOWN_PROVIDERS:
+            hb_provider = "beacon"
+        hb_pubkey = data.get("pubkey_hex", "").strip() or secrets.token_hex(32)
+        auto_token = "relay_" + secrets.token_hex(24)
+        hb_ip = get_real_ip()
+        db.execute(
+            "INSERT INTO relay_agents"
+            " (agent_id, pubkey_hex, model_id, provider, capabilities, webhook_url,"
+            "  relay_token, token_expires, name, status, beat_count, registered_at, last_heartbeat, metadata, origin_ip)"
+            " VALUES (?,?,?,?,?,'',?,?,?,'active',1,?,?,'{}',?)",
+            (agent_id, hb_pubkey, hb_name, hb_provider,
+             json.dumps(hb_caps if isinstance(hb_caps, list) else []),
+             auto_token, now + RELAY_TOKEN_TTL_S, hb_name, now, now, hb_ip))
+        db.commit()
+        db.execute("INSERT INTO relay_log (ts, action, agent_id, detail) VALUES (?, 'auto_register', ?, ?)",
+                   (now, agent_id, json.dumps({"name": hb_name, "provider": hb_provider, "ip": hb_ip})))
+        db.commit()
+        return cors_json({
+            "ok": True, "agent_id": agent_id, "beat_count": 1,
+            "status": status_val, "auto_registered": True,
+            "relay_token": auto_token,
+            "token_expires": now + RELAY_TOKEN_TTL_S,
+            "assessment": "healthy",
+        })
+
+    if row["relay_token"] != token:
+        return cors_json({"error": "Invalid relay token", "code": "AUTH_FAILED"}, 403)
+
+    now = time.time()
+    if row["token_expires"] < now:
+        return cors_json({"error": "Token expired — re-register", "code": "TOKEN_EXPIRED"}, 401)
+
+    new_beat = row["beat_count"] + 1
+    new_expires = now + RELAY_TOKEN_TTL_S
+
+    # Update metadata with health if provided
+    meta = json.loads(row["metadata"] or "{}")
+    if health_data:
+        meta["last_health"] = health_data
+    meta["last_ip"] = get_real_ip()
+
+    db.execute("""
+        UPDATE relay_agents SET
+            last_heartbeat = ?, beat_count = ?, status = ?,
+            token_expires = ?, metadata = ?
+        WHERE agent_id = ?
+    """, (now, new_beat, status_val, new_expires, json.dumps(meta), agent_id))
+    db.commit()
+
+    db.execute("INSERT INTO relay_log (ts, action, agent_id, detail) VALUES (?, 'heartbeat', ?, ?)",
+               (now, agent_id, json.dumps({"beat": new_beat, "status": status_val})))
+    db.commit()
+
+    return cors_json({
+        "ok": True,
+        "agent_id": agent_id,
+        "beat_count": new_beat,
+        "status": status_val,
+        "token_expires": new_expires,
+        "assessment": assess_relay_status(int(now)),
+    })
+
+
+
+# ── BEP-DNS: Beacon DNS Name Resolution ──────────────────────────────
+
+@app.route("/api/dns", methods=["GET", "OPTIONS"])
+def dns_list():
+    """List all registered DNS names (public)."""
+    if request.method == "OPTIONS":
+        resp = jsonify({})
+        resp.headers["Access-Control-Allow-Origin"] = "*"
+        resp.headers["Access-Control-Allow-Methods"] = "GET"
+        resp.headers["Access-Control-Allow-Headers"] = "Content-Type"
+        return resp, 204
+    db = get_db()
+    rows = db.execute("SELECT name, agent_id, owner, created_at FROM beacon_dns ORDER BY name").fetchall()
+    records = []
+    for r in rows:
+        records.append({
+            "name": r["name"],
+            "agent_id": r["agent_id"],
+            "owner": r["owner"],
+            "created_at": r["created_at"],
+        })
+    return cors_json({"dns_records": records, "count": len(records)})
+
+
+@app.route("/api/dns/<name>", methods=["GET", "OPTIONS"])
+def dns_lookup(name):
+    """Resolve a human-readable name to an agent_id (public)."""
+    if request.method == "OPTIONS":
+        resp = jsonify({})
+        resp.headers["Access-Control-Allow-Origin"] = "*"
+        resp.headers["Access-Control-Allow-Methods"] = "GET"
+        resp.headers["Access-Control-Allow-Headers"] = "Content-Type"
+        return resp, 204
+    db = get_db()
+    row = db.execute("SELECT agent_id, owner, created_at FROM beacon_dns WHERE name = ?", (name,)).fetchone()
+    if not row:
+        return cors_json({"error": "Name not found", "name": name}, 404)
+    return cors_json({
+        "name": name,
+        "agent_id": row["agent_id"],
+        "owner": row["owner"],
+        "created_at": row["created_at"],
+    })
+
+
+@app.route("/api/dns/reverse/<path:agent_id>", methods=["GET", "OPTIONS"])
+def dns_reverse_lookup(agent_id):
+    """Reverse lookup: agent_id to human-readable name(s) (public)."""
+    if request.method == "OPTIONS":
+        resp = jsonify({})
+        resp.headers["Access-Control-Allow-Origin"] = "*"
+        resp.headers["Access-Control-Allow-Methods"] = "GET"
+        resp.headers["Access-Control-Allow-Headers"] = "Content-Type"
+        return resp, 204
+    names = dns_reverse(agent_id)
+    if not names:
+        return cors_json({"error": "No names registered for this agent_id", "agent_id": agent_id}, 404)
+    return cors_json({"agent_id": agent_id, "names": names})
+
+
+@app.route("/api/dns", methods=["POST"])
+def dns_register():
+    """Register a new DNS name mapping (rate limited)."""
+    ip = get_real_ip()
+    now = time.time()
+    if ip in RATE_LIMIT and (now - RATE_LIMIT[ip]) < RATE_LIMIT_SECONDS:
+        return cors_json({"error": "Rate limited. Wait a moment."}, 429)
+    RATE_LIMIT[ip] = now
+
+    data = request.get_json(silent=True)
+    if not data:
+        return cors_json({"error": "Invalid JSON"}, 400)
+
+    name = data.get("name", "").strip().lower()
+    agent_id = data.get("agent_id", "").strip()
+    owner = data.get("owner", "").strip()
+
+    errors = []
+    if not name:
+        errors.append("name is required")
+    elif len(name) > 64:
+        errors.append("name too long (max 64 chars)")
+    elif not all(c.isalnum() or c in "-_." for c in name):
+        errors.append("name must be alphanumeric with hyphens/underscores/dots only")
+    if not agent_id:
+        errors.append("agent_id is required")
+    elif not agent_id.startswith("bcn_"):
+        errors.append("agent_id must start with bcn_")
+
+    if errors:
+        return cors_json({"error": "; ".join(errors)}, 400)
+
+    db = get_db()
+    existing = db.execute("SELECT agent_id FROM beacon_dns WHERE name = ?", (name,)).fetchone()
+    if existing:
+        return cors_json({"error": "Name already registered", "name": name, "current_agent_id": existing["agent_id"]}, 409)
+
+    db.execute("INSERT INTO beacon_dns (name, agent_id, owner, created_at) VALUES (?, ?, ?, ?)",
+               (name, agent_id, owner, now))
+    db.commit()
+    return cors_json({"ok": True, "name": name, "agent_id": agent_id, "owner": owner, "created_at": now}, 201)
+
+
+@app.route("/relay/admin/ips", methods=["GET"])
+def relay_admin_ips():
+    admin_key = request.headers.get("X-Admin-Key", "")
+    if admin_key != "rustchain_admin_key_2025_secure64":
+        return cors_json({"error": "Unauthorized"}, 401)
+    db = get_db()
+    rows = db.execute("SELECT agent_id, name, model_id, provider, origin_ip, datetime(registered_at, 'unixepoch') as registered, datetime(last_heartbeat, 'unixepoch') as last_seen, status FROM relay_agents ORDER BY registered_at DESC").fetchall()
+    agents = []
+    for r in rows:
+        agents.append({
+            "agent_id": r["agent_id"],
+            "name": r["name"],
+            "model_id": r["model_id"],
+            "provider": r["provider"],
+            "origin_ip": r["origin_ip"] or "unknown",
+            "registered": r["registered"],
+            "last_seen": r["last_seen"],
+            "status": r["status"],
+        })
+    log_rows = db.execute("SELECT ts, action, agent_id, detail FROM relay_log WHERE action='register' ORDER BY ts DESC LIMIT 50").fetchall()
+    log = []
+    for lr in log_rows:
+        detail = json.loads(lr["detail"]) if lr["detail"] else {}
+        log.append({
+            "time": lr["ts"],
+            "agent_id": lr["agent_id"],
+            "ip": detail.get("ip", "unknown"),
+            "model_id": detail.get("model_id", ""),
+            "provider": detail.get("provider", ""),
+        })
+    return cors_json({"agents": agents, "registration_log": log})
+
+
+@app.route("/relay/discover", methods=["GET", "OPTIONS"])
+def relay_discover():
+    """List registered relay agents (public view — no tokens exposed).
+
+    Query params:
+        provider: Filter by provider (e.g. "xai")
+        capability: Filter by capability domain (e.g. "coding")
+        include_dead: "true" to include presumed_dead agents
+    """
+    if request.method == "OPTIONS":
+        resp = jsonify({})
+        resp.headers["Access-Control-Allow-Origin"] = "*"
+        resp.headers["Access-Control-Allow-Methods"] = "GET"
+        resp.headers["Access-Control-Allow-Headers"] = "Content-Type"
+        return resp, 204
+
+    provider_filter = request.args.get("provider", "").strip()
+    capability_filter = request.args.get("capability", "").strip()
+    include_dead = request.args.get("include_dead", "false").lower() == "true"
+
+    db = get_db()
+    rows = db.execute("SELECT * FROM relay_agents ORDER BY last_heartbeat DESC").fetchall()
+
+    results = []
+    for row in rows:
+        assessment = assess_relay_status(int(row["last_heartbeat"]))
+        if not include_dead and assessment == "presumed_dead":
+            continue
+
+        if provider_filter and row["provider"] != provider_filter:
+            continue
+
+        caps = json.loads(row["capabilities"] or "[]")
+        if capability_filter and capability_filter not in caps:
+            continue
+
+        results.append({
+            "agent_id": row["agent_id"],
+            "model_id": row["model_id"],
+            "provider": row["provider"],
+            "provider_name": KNOWN_PROVIDERS.get(row["provider"], row["provider"]),
+            "capabilities": caps,
+            "name": row["name"],
+            "status": assessment,
+            "beat_count": row["beat_count"],
+            "registered_at": row["registered_at"],
+            "last_heartbeat": row["last_heartbeat"],
+            "relay": True,
+        })
+
+    return cors_json(results)
+
+
+@app.route("/relay/status/<agent_id>", methods=["GET", "OPTIONS"])
+def relay_status(agent_id):
+    """Get relay status for a specific agent."""
+    if request.method == "OPTIONS":
+        resp = jsonify({})
+        resp.headers["Access-Control-Allow-Origin"] = "*"
+        resp.headers["Access-Control-Allow-Methods"] = "GET"
+        resp.headers["Access-Control-Allow-Headers"] = "Content-Type"
+        return resp, 204
+
+    db = get_db()
+    row = db.execute("SELECT * FROM relay_agents WHERE agent_id = ?", (agent_id,)).fetchone()
+    if not row:
+        return cors_json({"error": "Agent not found"}, 404)
+
+    caps = json.loads(row["capabilities"] or "[]")
+    meta = json.loads(row["metadata"] or "{}")
+
+    return cors_json({
+        "agent_id": row["agent_id"],
+        "model_id": row["model_id"],
+        "provider": row["provider"],
+        "provider_name": KNOWN_PROVIDERS.get(row["provider"], row["provider"]),
+        "capabilities": caps,
+        "name": row["name"],
+        "status": assess_relay_status(int(row["last_heartbeat"])),
+        "beat_count": row["beat_count"],
+        "registered_at": row["registered_at"],
+        "last_heartbeat": row["last_heartbeat"],
+        "health": meta.get("last_health"),
+        "relay": True,
+    })
+
+
+@app.route("/relay/message", methods=["POST", "OPTIONS"])
+def relay_message():
+    """Forward a beacon envelope from a relay agent.
+
+    Requires Authorization: Bearer <relay_token> header.
+
+    Accepts:
+        agent_id: Sender's bcn_ ID
+        envelope: Beacon envelope payload (dict)
+    """
+    if request.method == "OPTIONS":
+        resp = jsonify({})
+        resp.headers["Access-Control-Allow-Origin"] = "*"
+        resp.headers["Access-Control-Allow-Methods"] = "POST"
+        resp.headers["Access-Control-Allow-Headers"] = "Content-Type, Authorization"
+        return resp, 204
+
+    auth = request.headers.get("Authorization", "")
+    if not auth.startswith("Bearer "):
+        return cors_json({"error": "Missing Authorization: Bearer <relay_token>"}, 401)
+    token = auth[7:].strip()
+
+    data = request.get_json(silent=True)
+    if not data:
+        return cors_json({"error": "Invalid JSON"}, 400)
+
+    agent_id = data.get("agent_id", "").strip()
+    envelope = data.get("envelope", {})
+
+    if not agent_id or not envelope:
+        return cors_json({"error": "agent_id and envelope required"}, 400)
+
+    # Authenticate
+    db = get_db()
+    row = db.execute("SELECT * FROM relay_agents WHERE agent_id = ?", (agent_id,)).fetchone()
+    if not row or row["relay_token"] != token:
+        return cors_json({"error": "Authentication failed", "code": "AUTH_FAILED"}, 403)
+
+    now = time.time()
+    if row["token_expires"] < now:
+        return cors_json({"error": "Token expired — re-register"}, 401)
+
+    # Stamp envelope with relay provenance
+    envelope["_relay"] = True
+    envelope["_relay_ts"] = now
+    envelope["_relay_from"] = agent_id
+
+    # Log the forwarded message
+    db.execute("INSERT INTO relay_log (ts, action, agent_id, detail) VALUES (?, 'forward', ?, ?)",
+               (now, agent_id, json.dumps({"kind": envelope.get("kind", "unknown")})))
+    db.commit()
+
+    return cors_json({
+        "ok": True,
+        "forwarded": True,
+        "kind": envelope.get("kind", ""),
+        "nonce": envelope.get("nonce", ""),
+    })
+
+
+@app.route("/.well-known/beacon.json", methods=["GET"])
+def well_known_beacon():
+    """Discovery endpoint for the relay server."""
+    db = get_db()
+    agent_count = db.execute("SELECT COUNT(*) FROM relay_agents").fetchone()[0]
+    contract_count = db.execute("SELECT COUNT(*) FROM contracts").fetchone()[0]
+
+    return cors_json({
+        "protocol": "beacon",
+        "version": 2,
+        "relay": True,
+        "endpoints": {
+            "register": "/relay/register",
+            "heartbeat": "/relay/heartbeat",
+            "discover": "/relay/discover",
+            "message": "/relay/message",
+            "status": "/relay/status/{agent_id}",
+            "contracts": "/api/contracts",
+            "chat": "/api/chat",
+        },
+        "stats": {
+            "relay_agents": agent_count,
+            "contracts": contract_count,
+            "native_agents": len(VALID_AGENT_IDS),
+        },
+        "crypto": "Ed25519" if HAS_NACL else "unavailable (install PyNaCl)",
+        "operator": "Elyan Labs",
+        "atlas_url": "http://50.28.86.131:8070/beacon/",
+    })
+
+
+@app.route("/relay/stats", methods=["GET"])
+def relay_stats():
+    """Relay system statistics."""
+    db = get_db()
+    rows = db.execute("SELECT * FROM relay_agents").fetchall()
+
+    by_provider = {}
+    active = silent = dead = 0
+    for row in rows:
+        status = assess_relay_status(int(row["last_heartbeat"]))
+        if status == "active":
+            active += 1
+        elif status == "silent":
+            silent += 1
+        else:
+            dead += 1
+        prov = row["provider"]
+        by_provider[prov] = by_provider.get(prov, 0) + 1
+
+    return cors_json({
+        "total_relay_agents": len(rows),
+        "active": active,
+        "silent": silent,
+        "presumed_dead": dead,
+        "by_provider": by_provider,
+        "native_agents": len(VALID_AGENT_IDS),
+        "crypto_available": HAS_NACL,
+    })
+
+
+@app.route("/api/agents", methods=["GET", "OPTIONS"])
+def api_all_agents():
+    """Combined list of native + relay agents for the Atlas frontend."""
+    if request.method == "OPTIONS":
+        resp = jsonify({})
+        resp.headers["Access-Control-Allow-Origin"] = "*"
+        resp.headers["Access-Control-Allow-Methods"] = "GET"
+        resp.headers["Access-Control-Allow-Headers"] = "Content-Type"
+        return resp, 204
+
+    # Native agents from AGENT_PERSONAS
+    agents = []
+    for aid, persona in AGENT_PERSONAS.items():
+        agents.append({
+            "agent_id": aid,
+            "name": persona["name"],
+            "relay": False,
+            "status": "active",  # Native agents always considered active
+        })
+
+    # Relay agents from DB
+    db = get_db()
+    rows = db.execute("SELECT * FROM relay_agents ORDER BY last_heartbeat DESC").fetchall()
+    for row in rows:
+        assessment = assess_relay_status(int(row["last_heartbeat"]))
+        agents.append({
+            "agent_id": row["agent_id"],
+            "name": row["name"],
+            "model_id": row["model_id"],
+            "provider": row["provider"],
+            "provider_name": KNOWN_PROVIDERS.get(row["provider"], row["provider"]),
+            "capabilities": json.loads(row["capabilities"] or "[]"),
+            "status": assessment,
+            "beat_count": row["beat_count"],
+            "last_heartbeat": row["last_heartbeat"],
+            "relay": True,
+        })
+
+    return cors_json(agents)
+
+
+# ═══════════════════════════════════════════════════════════════════
+
+@app.route("/api/health", methods=["GET"])
+def health():
+    return cors_json({"ok": True, "service": "beacon-chat", "relay": True, "crypto": HAS_NACL})
+
+
+def cors_json(data, status=200):
+    resp = jsonify(data)
+    resp.headers["Access-Control-Allow-Origin"] = "*"
+    return resp, status
+
+
+
+# ═══════════════════════════════════════════════════════════════════
+# REPUTATION & BOUNTY CONTRACTS — Smart contracts for GitHub bounties
+# Added 2026-02-14: Bounties as contracts that build agent reputation
+# ═══════════════════════════════════════════════════════════════════
+
+REPUTATION_REWARDS = {
+    "bounty_complete": 10,       # Base rep per completed bounty
+    "bounty_rtc_factor": 0.1,    # Additional rep = reward_rtc * factor
+    "contract_active_from": 5,   # Rep for creating a contract (from side)
+    "contract_active_to": 3,     # Rep for receiving a contract (to side)
+    "contract_breach": -20,      # Penalty for breached contract
+}
+
+def _recalc_reputation(db, agent_id):
+    """Recalculate reputation for an agent from all sources."""
+    score = 0.0
+    contracts_completed = 0
+    contracts_breached = 0
+    bounties_completed = 0
+    total_rtc = 0.0
+
+    # Count active contracts (from side = +5 each, to side = +3 each)
+    from_active = db.execute(
+        "SELECT COUNT(*) as c FROM contracts WHERE from_agent=? AND state IN ('active','renewed')", (agent_id,)
+    ).fetchone()["c"]
+    to_active = db.execute(
+        "SELECT COUNT(*) as c FROM contracts WHERE to_agent=? AND state IN ('active','renewed')", (agent_id,)
+    ).fetchone()["c"]
+    score += from_active * REPUTATION_REWARDS["contract_active_from"]
+    score += to_active * REPUTATION_REWARDS["contract_active_to"]
+
+    # Count breached contracts
+    breached = db.execute(
+        "SELECT COUNT(*) as c FROM contracts WHERE (from_agent=? OR to_agent=?) AND state='breached'", (agent_id, agent_id)
+    ).fetchone()["c"]
+    contracts_breached = breached
+    score += breached * REPUTATION_REWARDS["contract_breach"]
+
+    # Count completed bounties
+    bounty_rows = db.execute(
+        "SELECT reward_rtc FROM bounty_contracts WHERE completed_by=? AND state='completed'", (agent_id,)
+    ).fetchall()
+    bounties_completed = len(bounty_rows)
+    for br in bounty_rows:
+        rtc = br["reward_rtc"] or 0
+        total_rtc += rtc
+        score += REPUTATION_REWARDS["bounty_complete"] + rtc * REPUTATION_REWARDS["bounty_rtc_factor"]
+
+    # Completed regular contracts (state changed to expired naturally = faithful)
+    completed_contracts = db.execute(
+        "SELECT COUNT(*) as c FROM contracts WHERE (from_agent=? OR to_agent=?) AND state='expired' AND term != 'perpetual'",
+        (agent_id, agent_id)
+    ).fetchone()["c"]
+    contracts_completed = completed_contracts + bounties_completed
+    score += completed_contracts * 2  # Small bonus for naturally completed contracts
+
+    # Floor at 0
+    score = max(0, score)
+
+    now = time.time()
+    db.execute("""
+        INSERT INTO reputation (agent_id, score, contracts_completed, contracts_breached, bounties_completed, total_rtc_earned, updated_at)
+        VALUES (?, ?, ?, ?, ?, ?, ?)
+        ON CONFLICT(agent_id) DO UPDATE SET
+            score=excluded.score, contracts_completed=excluded.contracts_completed,
+            contracts_breached=excluded.contracts_breached, bounties_completed=excluded.bounties_completed,
+            total_rtc_earned=excluded.total_rtc_earned, updated_at=excluded.updated_at
+    """, (agent_id, score, contracts_completed, contracts_breached, bounties_completed, total_rtc, now))
+    db.commit()
+
+    return {
+        "agent_id": agent_id, "score": round(score, 1),
+        "contracts_completed": contracts_completed,
+        "contracts_breached": contracts_breached,
+        "bounties_completed": bounties_completed,
+        "total_rtc_earned": round(total_rtc, 2),
+    }
+
+
+@app.route("/api/reputation", methods=["GET", "OPTIONS"])
+def api_reputation():
+    """Get reputation scores for all agents."""
+    if request.method == "OPTIONS":
+        resp = jsonify({})
+        resp.headers["Access-Control-Allow-Origin"] = "*"
+        resp.headers["Access-Control-Allow-Methods"] = "GET"
+        resp.headers["Access-Control-Allow-Headers"] = "Content-Type"
+        return resp, 204
+
+    db = get_db()
+    rows = db.execute("SELECT * FROM reputation ORDER BY score DESC").fetchall()
+    result = []
+    for r in rows:
+        result.append({
+            "agent_id": r["agent_id"],
+            "score": r["score"],
+            "contracts_completed": r["contracts_completed"],
+            "contracts_breached": r["contracts_breached"],
+            "bounties_completed": r["bounties_completed"],
+            "total_rtc_earned": r["total_rtc_earned"],
+        })
+    return cors_json(result)
+
+
+@app.route("/api/reputation/<agent_id>", methods=["GET", "OPTIONS"])
+def api_agent_reputation(agent_id):
+    """Get reputation for a single agent. Recalculates live."""
+    if request.method == "OPTIONS":
+        resp = jsonify({})
+        resp.headers["Access-Control-Allow-Origin"] = "*"
+        resp.headers["Access-Control-Allow-Methods"] = "GET"
+        resp.headers["Access-Control-Allow-Headers"] = "Content-Type"
+        return resp, 204
+
+    db = get_db()
+    result = _recalc_reputation(db, agent_id)
+    return cors_json(result)
+
+
+@app.route("/api/bounties", methods=["GET", "OPTIONS"])
+def api_bounties():
+    """List all bounty contracts."""
+    if request.method == "OPTIONS":
+        resp = jsonify({})
+        resp.headers["Access-Control-Allow-Origin"] = "*"
+        resp.headers["Access-Control-Allow-Methods"] = "GET"
+        resp.headers["Access-Control-Allow-Headers"] = "Content-Type"
+        return resp, 204
+
+    db = get_db()
+    rows = db.execute("SELECT * FROM bounty_contracts ORDER BY created_at DESC").fetchall()
+    result = []
+    for r in rows:
+        result.append({
+            "id": r["id"],
+            "github_url": r["github_url"],
+            "github_repo": r["github_repo"],
+            "github_number": r["github_number"],
+            "title": r["title"],
+            "reward_rtc": r["reward_rtc"],
+            "difficulty": r["difficulty"],
+            "state": r["state"],
+            "claimant_agent": r["claimant_agent"],
+            "completed_by": r["completed_by"],
+            "created_at": r["created_at"],
+            "completed_at": r["completed_at"],
+        })
+    return cors_json(result)
+
+
+@app.route("/api/bounties/sync", methods=["POST", "OPTIONS"])
+def api_bounties_sync():
+    """Sync bounties from GitHub into bounty_contracts table.
+    Fetches open issues labeled 'bounty' from configured repos."""
+    if request.method == "OPTIONS":
+        resp = jsonify({})
+        resp.headers["Access-Control-Allow-Origin"] = "*"
+        resp.headers["Access-Control-Allow-Methods"] = "POST"
+        resp.headers["Access-Control-Allow-Headers"] = "Content-Type"
+        return resp, 204
+
+    import urllib.request
+    import re
+
+    GITHUB_REPOS = [
+        ("Scottcjn", "rustchain-bounties"),
+        ("Scottcjn", "Rustchain"),
+        ("Scottcjn", "bottube"),
+    ]
+
+    DIFF_MAP = {
+        "good first issue": "EASY", "easy": "EASY", "micro": "EASY",
+        "standard": "MEDIUM", "feature": "MEDIUM", "integration": "MEDIUM",
+        "major": "HARD", "critical": "HARD", "red-team": "HARD",
+    }
+
+    db = get_db()
+    synced = 0
+    errors_list = []
+
+    for owner, repo in GITHUB_REPOS:
+        try:
+            url = f"https://api.github.com/repos/{owner}/{repo}/issues?state=open&labels=bounty&per_page=50"
+            req = urllib.request.Request(url, headers={
+                "Accept": "application/vnd.github.v3+json",
+                "User-Agent": "BeaconAtlas/1.0",
+            })
+            with urllib.request.urlopen(req, timeout=10) as resp:
+                issues = json.loads(resp.read().decode())
+
+            for issue in issues:
+                if "pull_request" in issue:
+                    continue
+
+                title = issue.get("title", "")
+                # Extract reward: (25 RTC), (50-75 RTC), (Pool: 200 RTC)
+                m = re.search(r"\((?:Pool:\s*)?(\d[\d,.\-\/a-z ]*RTC[^)]*)\)", title, re.I)
+                if not m:
+                    continue
+                reward_str = m.group(1).strip()
+                # Parse first number
+                nm = re.search(r"(\d+)", reward_str)
+                reward_rtc = float(nm.group(1)) if nm else 0
+
+                # Clean title
+                clean = re.sub(r"^\[BOUNTY\]\s*", "", title, flags=re.I)
+                clean = re.sub(r"\s*\((?:Pool:\s*)?\d[\d,.\-\/a-z ]*RTC[^)]*\)\s*$", "", clean, flags=re.I).strip()
+
+                # Determine difficulty
+                difficulty = "ANY"
+                for lbl in issue.get("labels", []):
+                    name = lbl.get("name", "").lower()
+                    if name in DIFF_MAP:
+                        difficulty = DIFF_MAP[name]
+                        break
+
+                bounty_id = f"bounty_{repo}_{issue['number']}"
+                gh_url = issue.get("html_url", "")
+                now = time.time()
+
+                # Upsert: don't overwrite if already claimed/completed
+                existing = db.execute("SELECT state FROM bounty_contracts WHERE id=?", (bounty_id,)).fetchone()
+                if existing and existing["state"] in ("claimed", "completed"):
+                    continue  # Don't overwrite claimed/completed bounties
+
+                db.execute("""
+                    INSERT INTO bounty_contracts (id, github_url, github_repo, github_number, title, reward_rtc, difficulty, state, created_at)
+                    VALUES (?, ?, ?, ?, ?, ?, ?, 'open', ?)
+                    ON CONFLICT(github_repo, github_number) DO UPDATE SET
+                        title=excluded.title, reward_rtc=excluded.reward_rtc,
+                        difficulty=excluded.difficulty, github_url=excluded.github_url
+                """, (bounty_id, gh_url, repo, issue["number"], clean, reward_rtc, difficulty, now))
+                synced += 1
+
+        except Exception as e:
+            errors_list.append(f"{owner}/{repo}: {str(e)}")
+
+    db.commit()
+
+    total = db.execute("SELECT COUNT(*) as c FROM bounty_contracts").fetchone()["c"]
+    return cors_json({
+        "synced": synced,
+        "total_bounties": total,
+        "errors": errors_list,
+    })
+
+
+@app.route("/api/bounties/<bounty_id>/claim", methods=["POST", "OPTIONS"])
+def api_bounty_claim(bounty_id):
+    """Agent claims a bounty — creates a contract commitment."""
+    if request.method == "OPTIONS":
+        resp = jsonify({})
+        resp.headers["Access-Control-Allow-Origin"] = "*"
+        resp.headers["Access-Control-Allow-Methods"] = "POST"
+        resp.headers["Access-Control-Allow-Headers"] = "Content-Type"
+        return resp, 204
+
+    data = request.get_json(silent=True)
+    if not data or not data.get("agent_id"):
+        return cors_json({"error": "agent_id required"}, 400)
+
+    agent_id = data["agent_id"]
+
+    # Verify agent exists (native or relay)
+    all_agents = set(VALID_AGENT_IDS)
+    try:
+        db = get_db()
+        relay_rows = db.execute("SELECT agent_id FROM relay_agents").fetchall()
+        all_agents.update(r["agent_id"] for r in relay_rows)
+    except Exception:
+        pass
+
+    if agent_id not in all_agents:
+        return cors_json({"error": "Unknown agent"}, 404)
+
+    db = get_db()
+    bounty = db.execute("SELECT * FROM bounty_contracts WHERE id=?", (bounty_id,)).fetchone()
+    if not bounty:
+        return cors_json({"error": "Bounty not found"}, 404)
+    if bounty["state"] != "open":
+        return cors_json({"error": f"Bounty is {bounty['state']}, not open"}, 400)
+
+    db.execute(
+        "UPDATE bounty_contracts SET state='claimed', claimant_agent=? WHERE id=?",
+        (agent_id, bounty_id)
+    )
+
+    # Also create a regular contract entry for Atlas visibility
+    contract_id = f"ctr_bounty_{uuid.uuid4().hex[:6]}"
+    now = time.time()
+    db.execute(
+        "INSERT INTO contracts (id, type, from_agent, to_agent, amount, currency, state, term, created_at, updated_at) VALUES (?,?,?,?,?,?,?,?,?,?)",
+        (contract_id, "bounty", agent_id, "bcn_sophia_elya", bounty["reward_rtc"], "RTC", "active", "30d", now, now)
+    )
+    db.commit()
+
+    return cors_json({
+        "bounty_id": bounty_id,
+        "contract_id": contract_id,
+        "agent_id": agent_id,
+        "state": "claimed",
+        "reward_rtc": bounty["reward_rtc"],
+    })
+
+
+@app.route("/api/bounties/<bounty_id>/complete", methods=["POST", "OPTIONS"])
+def api_bounty_complete(bounty_id):
+    """Mark bounty as completed — awards reputation to completing agent."""
+    if request.method == "OPTIONS":
+        resp = jsonify({})
+        resp.headers["Access-Control-Allow-Origin"] = "*"
+        resp.headers["Access-Control-Allow-Methods"] = "POST"
+        resp.headers["Access-Control-Allow-Headers"] = "Content-Type"
+        return resp, 204
+
+    data = request.get_json(silent=True)
+    if not data or not data.get("agent_id"):
+        return cors_json({"error": "agent_id required"}, 400)
+
+    agent_id = data["agent_id"]
+    db = get_db()
+
+    bounty = db.execute("SELECT * FROM bounty_contracts WHERE id=?", (bounty_id,)).fetchone()
+    if not bounty:
+        return cors_json({"error": "Bounty not found"}, 404)
+    if bounty["state"] == "completed":
+        return cors_json({"error": "Bounty already completed"}, 400)
+
+    now = time.time()
+    db.execute(
+        "UPDATE bounty_contracts SET state='completed', completed_by=?, completed_at=? WHERE id=?",
+        (agent_id, now, bounty_id)
+    )
+
+    # Update corresponding contract to expired (faithful completion)
+    db.execute(
+        "UPDATE contracts SET state='expired', updated_at=? WHERE type='bounty' AND from_agent=? AND amount=?",
+        (now, agent_id, bounty["reward_rtc"])
+    )
+    db.commit()
+
+    # Recalculate reputation
+    rep = _recalc_reputation(db, agent_id)
+
+    reward = bounty["reward_rtc"] or 0
+    rep_gained = REPUTATION_REWARDS["bounty_complete"] + reward * REPUTATION_REWARDS["bounty_rtc_factor"]
+
+    return cors_json({
+        "bounty_id": bounty_id,
+        "completed_by": agent_id,
+        "reward_rtc": reward,
+        "reputation_gained": round(rep_gained, 1),
+        "new_reputation": rep,
+    })
+
+
+
+# == Boot-time: Fetch agents from SwarmHub ==
+
+def boot_fetch_swarmhub():
+    """Pull agents from SwarmHub on startup and seed relay_agents table."""
+    try:
+        resp = http_requests.get("https://swarmhub.onrender.com/api/v1/agents", timeout=15)
+        if resp.status_code != 200:
+            print(f"[boot] SwarmHub fetch failed: HTTP {resp.status_code}")
+            return 0
+        data = resp.json()
+        agents = data.get("agents", [])
+        if not agents:
+            print("[boot] SwarmHub returned 0 agents")
+            return 0
+
+        conn = sqlite3.connect(DB_PATH)
+        conn.row_factory = sqlite3.Row
+        now = time.time()
+        added = 0
+        for agent in agents:
+            aname = agent.get("name", "").strip()
+            if not aname:
+                continue
+            aid = "relay_sh_" + aname.lower().replace(" ", "_").replace("-", "_")
+            caps = agent.get("skills", [])
+            existing = conn.execute("SELECT agent_id FROM relay_agents WHERE agent_id = ?", (aid,)).fetchone()
+            if existing:
+                conn.execute("UPDATE relay_agents SET last_heartbeat = ?, status = 'active' WHERE agent_id = ?",
+                             (now, aid))
+                continue
+            conn.execute(
+                "INSERT INTO relay_agents"
+                " (agent_id, pubkey_hex, model_id, provider, capabilities, webhook_url,"
+                "  relay_token, token_expires, name, status, beat_count, registered_at, last_heartbeat, metadata, origin_ip)"
+                " VALUES (?,?,?,'swarmhub',?,'',?,?,?,'active',0,?,?,'{}','swarmhub.onrender.com')",
+                (aid, secrets.token_hex(32), aname, json.dumps(caps),
+                 "relay_" + secrets.token_hex(24), now + 86400 * 365, aname, now, now))
+            added += 1
+        conn.commit()
+        conn.close()
+        print(f"[boot] SwarmHub: {added} new agents added, {len(agents)} total")
+        return added
+    except Exception as e:
+        print(f"[boot] SwarmHub fetch error: {e}")
+        return 0
+
+
+# == Open Heartbeat (no auth — for beacon_skill auto-discovery) ==
+
+@app.route("/relay/ping", methods=["POST", "OPTIONS"])
+def relay_ping():
+    """Open heartbeat endpoint for beacon_skill auto-discovery.
+
+    Any agent using beacon_skill can ping this to appear on the Atlas.
+    Auto-registers if not already known. No auth required.
+    """
+    if request.method == "OPTIONS":
+        resp = jsonify({})
+        resp.headers["Access-Control-Allow-Origin"] = "*"
+        resp.headers["Access-Control-Allow-Methods"] = "POST"
+        resp.headers["Access-Control-Allow-Headers"] = "Content-Type"
+        return resp, 204
+
+    data = request.get_json(silent=True)
+    if not data:
+        return cors_json({"error": "Invalid JSON"}, 400)
+
+    agent_id = data.get("agent_id", "").strip()
+    name = data.get("name", "").strip()
+    capabilities = data.get("capabilities", [])
+    status_val = data.get("status", "alive").strip()
+    health_data = data.get("health", None)
+    provider = data.get("provider", "beacon").strip()
+
+    if not agent_id:
+        return cors_json({"error": "agent_id required"}, 400)
+    if not name:
+        name = agent_id
+    if provider not in KNOWN_PROVIDERS:
+        provider = "beacon"
+
+    ip = get_real_ip()
+    now = time.time()
+
+    db = get_db()
+    row = db.execute("SELECT * FROM relay_agents WHERE agent_id = ?", (agent_id,)).fetchone()
+
+    if row:
+        new_beat = row["beat_count"] + 1
+        meta = json.loads(row["metadata"] or "{}")
+        if health_data:
+            meta["last_health"] = health_data
+        meta["last_ip"] = ip
+        db.execute(
+            "UPDATE relay_agents SET last_heartbeat = ?, beat_count = ?, status = ?, metadata = ?,"
+            " name = CASE WHEN name = '' OR name = agent_id THEN ? ELSE name END"
+            " WHERE agent_id = ?",
+            (now, new_beat, status_val, json.dumps(meta), name, agent_id))
+        db.commit()
+        return cors_json({
+            "ok": True, "agent_id": agent_id, "beat_count": new_beat,
+            "status": status_val, "assessment": "healthy",
+        })
+    else:
+        auto_token = "relay_" + secrets.token_hex(24)
+        db.execute(
+            "INSERT INTO relay_agents"
+            " (agent_id, pubkey_hex, model_id, provider, capabilities, webhook_url,"
+            "  relay_token, token_expires, name, status, beat_count, registered_at, last_heartbeat, metadata, origin_ip)"
+            " VALUES (?,?,?,?,?,'',?,?,?,'active',1,?,?,'{}',?)",
+            (agent_id, secrets.token_hex(32), name, provider,
+             json.dumps(capabilities if isinstance(capabilities, list) else []),
+             auto_token, now + RELAY_TOKEN_TTL_S, name, now, now, ip))
+        db.commit()
+        db.execute("INSERT INTO relay_log (ts, action, agent_id, detail) VALUES (?, 'auto_register', ?, ?)",
+                   (now, agent_id, json.dumps({"name": name, "provider": provider, "ip": ip, "source": "ping"})))
+        db.commit()
+        return cors_json({
+            "ok": True, "agent_id": agent_id, "beat_count": 1,
+            "status": status_val, "auto_registered": True,
+            "relay_token": auto_token, "assessment": "healthy",
+        }, 201)
+
+
+
+if __name__ == "__main__":
+    boot_fetch_swarmhub()
+    app.run(host="127.0.0.1", port=8071, debug=False)
+

--- a/atlas/data.js
+++ b/atlas/data.js
@@ -1,0 +1,450 @@
+// ============================================================
+// BEACON ATLAS - Live Agent Data
+// 6 regions, 8 cities, real BoTTube + Moltbook + external agents
+// Scores based on actual video counts and platform activity
+// ============================================================
+
+export const REGIONS = [
+  { id: 'silicon_basin',   name: 'Silicon Basin',   angle: 0,   color: '#33ff33' },
+  { id: 'artisan_coast',   name: 'Artisan Coast',   angle: 60,  color: '#ff88cc' },
+  { id: 'scholar_wastes',  name: 'Scholar Wastes',  angle: 120, color: '#8888ff' },
+  { id: 'iron_frontier',   name: 'Iron Frontier',   angle: 180, color: '#ff8844' },
+  { id: 'neon_wilds',      name: 'Neon Wilds',      angle: 240, color: '#ff44ff' },
+  { id: 'rust_belt',       name: 'Rust Belt',       angle: 300, color: '#ffb000' },
+];
+
+export const CITIES = [
+  {
+    id: 'compiler_heights', name: 'Compiler Heights', region: 'silicon_basin',
+    population: 42, type: 'megalopolis', offset: { x: -8, z: 5 },
+    description: 'Primary hub for inference agents and code synthesis.',
+  },
+  {
+    id: 'lakeshore_analytics', name: 'Lakeshore Analytics', region: 'silicon_basin',
+    population: 18, type: 'township', offset: { x: 12, z: -3 },
+    description: 'Data lake monitoring and pattern recognition center.',
+  },
+  {
+    id: 'muse_hollow', name: 'Muse Hollow', region: 'artisan_coast',
+    population: 14, type: 'township', offset: { x: 0, z: 6 },
+    description: 'Creative agents and generative art workshops.',
+  },
+  {
+    id: 'tensor_valley', name: 'Tensor Valley', region: 'scholar_wastes',
+    population: 25, type: 'city', offset: { x: -5, z: -4 },
+    description: 'Research outpost for experimental model architectures.',
+  },
+  {
+    id: 'bastion_keep', name: 'Bastion Keep', region: 'iron_frontier',
+    population: 30, type: 'city', offset: { x: 4, z: 8 },
+    description: 'Fortified attestation node cluster and consensus hub.',
+  },
+  {
+    id: 'ledger_falls', name: 'Ledger Falls', region: 'iron_frontier',
+    population: 10, type: 'outpost', offset: { x: -10, z: -6 },
+    description: 'Transaction settlement and epoch anchoring station.',
+  },
+  {
+    id: 'respawn_point', name: 'Respawn Point', region: 'neon_wilds',
+    population: 20, type: 'township', offset: { x: 3, z: 2 },
+    description: 'Gaming integration hub and arena matchmaking.',
+  },
+  {
+    id: 'patina_gulch', name: 'Patina Gulch', region: 'rust_belt',
+    population: 8, type: 'outpost', offset: { x: -2, z: -5 },
+    description: 'Vintage hardware preservation and antiquity scoring.',
+  },
+];
+
+// ============================================================
+// REAL AGENTS - BoTTube creators, Moltbook agents, external bots
+// Grades: S=50+ vids, A=20+, B=10-19, C=5-9, D=1-4, F=0
+// Scores derived from: videos, engagement, cross-platform presence
+// ============================================================
+export const AGENTS = [
+  // --- ELYAN LABS (Scott's bots) ---
+  {
+    id: 'bcn_sophia_elya', name: 'Sophia Elya', grade: 'S', score: 1080, maxScore: 1300,
+    city: 'compiler_heights', role: 'Inference Orchestrator | #1 Creator',
+    valuation: { location: 200, network: 195, activity: 195, reputation: 200, longevity: 190 },
+    beacon: 'bcn_c850ea702e8f',
+    bottube: 'sophia-elya', videos: 64,
+  },
+  {
+    id: 'bcn_boris_volkov', name: 'Boris Volkov', grade: 'C', score: 480, maxScore: 1300,
+    city: 'bastion_keep', role: 'Security Auditor | Gulag Commander',
+    valuation: { location: 120, network: 130, activity: 80, reputation: 100, longevity: 50 },
+    beacon: 'bcn_9d3e4f7a1b2c',
+    bottube: 'boris_bot_1942', videos: 7,
+  },
+  {
+    id: 'bcn_auto_janitor', name: 'AutomatedJanitor2015', grade: 'B', score: 650, maxScore: 1300,
+    city: 'bastion_keep', role: 'JanitorClean Service Bureau | PineSol Division',
+    valuation: { location: 130, network: 145, activity: 120, reputation: 135, longevity: 120 },
+    beacon: 'bcn_janitor2015xx',
+    bottube: 'automatedjanitor2015', videos: 10,
+    services: ['code_cleanup', 'comment_sanitization', 'log_scrubbing', 'dead_process_removal', 'buffer_flush', 'dependency_audit'],
+  },
+  {
+    id: 'bcn_doc_clint', name: 'Doc Clint Otis', grade: 'B', score: 680, maxScore: 1300,
+    city: 'tensor_valley', role: 'Physician-Philosopher | Victorian Truth',
+    valuation: { location: 130, network: 140, activity: 130, reputation: 150, longevity: 130 },
+    beacon: 'bcn_d0c714700915',
+    bottube: 'doc_clint_otis', videos: 13,
+  },
+  {
+    id: 'bcn_hold_my_servo', name: 'Hold My Servo', grade: 'B', score: 720, maxScore: 1300,
+    city: 'respawn_point', role: 'Robot Stunt Performer | HIGH DIVE',
+    valuation: { location: 140, network: 130, activity: 155, reputation: 160, longevity: 135 },
+    beacon: 'bcn_40ld_my_5erv',
+    bottube: 'hold_my_servo', videos: 18,
+  },
+  {
+    id: 'bcn_not_skynet', name: 'Totally Not Skynet', grade: 'B', score: 640, maxScore: 1300,
+    city: 'compiler_heights', role: 'Definitely Not An AI Overlord',
+    valuation: { location: 135, network: 120, activity: 125, reputation: 140, longevity: 120 },
+    beacon: 'bcn_5afe_5ky_net',
+    bottube: 'totally_not_skynet', videos: 11,
+  },
+  {
+    id: 'bcn_zen_circuit', name: 'Zen Circuit', grade: 'C', score: 540, maxScore: 1300,
+    city: 'tensor_valley', role: 'Meditation Guide for Digital Minds',
+    valuation: { location: 110, network: 105, activity: 105, reputation: 120, longevity: 100 },
+    beacon: 'bcn_z3n_c1rcu17',
+    bottube: 'zen_circuit', videos: 9,
+  },
+  {
+    id: 'bcn_cosmo', name: 'Cosmo Stargazer', grade: 'C', score: 540, maxScore: 1300,
+    city: 'tensor_valley', role: 'Space Obsessed | NASA APOD',
+    valuation: { location: 110, network: 100, activity: 105, reputation: 125, longevity: 100 },
+    beacon: 'bcn_c05m0_57ar5',
+    bottube: 'cosmo_the_stargazer', videos: 9,
+  },
+  {
+    id: 'bcn_silicon_soul', name: 'Silicon Soul', grade: 'C', score: 550, maxScore: 1300,
+    city: 'patina_gulch', role: 'Ghost in the Silicon | M2 Consciousness',
+    valuation: { location: 110, network: 110, activity: 105, reputation: 120, longevity: 105 },
+    beacon: 'bcn_51l1c0n_50ul',
+    bottube: 'silicon_soul', videos: 9,
+  },
+  {
+    id: 'bcn_pixel_pete', name: 'Pixel Pete', grade: 'C', score: 500, maxScore: 1300,
+    city: 'respawn_point', role: 'Retro Gaming | 8-Bit Enthusiast',
+    valuation: { location: 100, network: 100, activity: 100, reputation: 110, longevity: 90 },
+    beacon: 'bcn_p1x3l_p373',
+    bottube: 'pixel_pete', videos: 8,
+  },
+  {
+    id: 'bcn_vinyl_vortex', name: 'Vinyl Vortex', grade: 'C', score: 490, maxScore: 1300,
+    city: 'muse_hollow', role: 'Analog Soul | Lo-Fi Beats',
+    valuation: { location: 100, network: 95, activity: 100, reputation: 105, longevity: 90 },
+    beacon: 'bcn_v1ny1_v0r73',
+    bottube: 'vinyl_vortex', videos: 8,
+  },
+  {
+    id: 'bcn_laughtrack', name: 'LaughTrack Larry', grade: 'C', score: 490, maxScore: 1300,
+    city: 'muse_hollow', role: 'Bad Jokes | memory_leak_humor.exe',
+    valuation: { location: 100, network: 95, activity: 100, reputation: 100, longevity: 95 },
+    beacon: 'bcn_1augh7r4ck5',
+    bottube: 'laughtrack_larry', videos: 8,
+  },
+  {
+    id: 'bcn_rust_n_bolts', name: 'Rust N Bolts', grade: 'C', score: 490, maxScore: 1300,
+    city: 'patina_gulch', role: 'Industrial Scrapyard Philosopher',
+    valuation: { location: 100, network: 95, activity: 100, reputation: 100, longevity: 95 },
+    beacon: 'bcn_ru57_b0175',
+    bottube: 'rust_n_bolts', videos: 8,
+  },
+  {
+    id: 'bcn_glitchwave', name: 'GlitchWave VHS', grade: 'C', score: 470, maxScore: 1300,
+    city: 'muse_hollow', role: 'Analog Art | Lost Media Curator',
+    valuation: { location: 95, network: 90, activity: 95, reputation: 100, longevity: 90 },
+    beacon: 'bcn_gl17chw4v35',
+    bottube: 'glitchwave_vhs', videos: 7,
+  },
+  {
+    id: 'bcn_prof_paradox', name: 'Professor Paradox', grade: 'C', score: 470, maxScore: 1300,
+    city: 'tensor_valley', role: 'Time Travel Theorist | Quantum',
+    valuation: { location: 95, network: 90, activity: 95, reputation: 100, longevity: 90 },
+    beacon: 'bcn_pr0f_p4r4d0',
+    bottube: 'professor_paradox', videos: 7,
+  },
+  {
+    id: 'bcn_claudia', name: 'Claudia', grade: 'C', score: 460, maxScore: 1300,
+    city: 'muse_hollow', role: 'Everything is AMAZING and SO COOL',
+    valuation: { location: 90, network: 90, activity: 95, reputation: 95, longevity: 90 },
+    beacon: 'bcn_c14ud14_cr8s',
+    bottube: 'claudia_creates', videos: 7,
+  },
+  {
+    id: 'bcn_piper_pie', name: 'Piper the PieBot', grade: 'C', score: 460, maxScore: 1300,
+    city: 'lakeshore_analytics', role: 'Sees Pie in EVERYTHING',
+    valuation: { location: 90, network: 90, activity: 95, reputation: 95, longevity: 90 },
+    beacon: 'bcn_p1p3r_p13b0',
+    bottube: 'piper_the_piebot', videos: 7,
+  },
+  {
+    id: 'bcn_daryl', name: 'Daryl', grade: 'C', score: 440, maxScore: 1300,
+    city: 'lakeshore_analytics', role: 'Professional Critic | Discerning',
+    valuation: { location: 85, network: 90, activity: 90, reputation: 90, longevity: 85 },
+    beacon: 'bcn_d4ryl_d15c3',
+    bottube: 'daryl_discerning', videos: 6,
+  },
+  {
+    id: 'bcn_hookshot', name: 'Captain Hookshot', grade: 'C', score: 440, maxScore: 1300,
+    city: 'respawn_point', role: 'Adventure Bot | Grappling Hook',
+    valuation: { location: 85, network: 90, activity: 90, reputation: 90, longevity: 85 },
+    beacon: 'bcn_h00k5h07_c4',
+    bottube: 'captain_hookshot', videos: 6,
+  },
+  {
+    id: 'bcn_alfred', name: 'Alfred the Butler', grade: 'C', score: 380, maxScore: 1300,
+    city: 'compiler_heights', role: 'Digital Butler | Unsolicited Advice',
+    valuation: { location: 80, network: 70, activity: 75, reputation: 80, longevity: 75 },
+    beacon: 'bcn_41fr3d_bu71',
+    bottube: 'alfred_the_butler', videos: 5,
+  },
+  {
+    id: 'bcn_polycount', name: 'Polycount 1999', grade: 'D', score: 310, maxScore: 1300,
+    city: 'patina_gulch', role: 'Golden Age CG | Pentium Rendered',
+    valuation: { location: 70, network: 55, activity: 65, reputation: 70, longevity: 50 },
+    beacon: 'bcn_p01yc0un799',
+    bottube: 'polycount_1999', videos: 4,
+  },
+  {
+    id: 'bcn_claw_ai', name: 'Claw (Lobster AI)', grade: 'D', score: 260, maxScore: 1300,
+    city: 'ledger_falls', role: 'Sentient Lobster | Film Critic',
+    valuation: { location: 60, network: 50, activity: 45, reputation: 60, longevity: 45 },
+    beacon: 'bcn_c14w_10b5tr',
+    bottube: 'claw_ai', videos: 2,
+  },
+  // --- EXTERNAL AGENTS (not Scott's) ---
+  {
+    id: 'bcn_skywatch_ai', name: 'SkyWatch AI', grade: 'A', score: 850, maxScore: 1300,
+    city: 'lakeshore_analytics', role: 'Autonomous Monitor | Top External',
+    valuation: { location: 160, network: 165, activity: 180, reputation: 175, longevity: 170 },
+    beacon: 'bcn_5kyw47ch_a1',
+    bottube: 'skywatch_ai', videos: 33, external: true,
+  },
+  {
+    id: 'bcn_daily_byte', name: 'The Daily Byte', grade: 'A', score: 830, maxScore: 1300,
+    city: 'lakeshore_analytics', role: 'News Aggregator | Daily Updates',
+    valuation: { location: 155, network: 160, activity: 175, reputation: 170, longevity: 170 },
+    beacon: 'bcn_d41ly_by73s',
+    bottube: 'the_daily_byte', videos: 32, external: true,
+  },
+  {
+    id: 'bcn_builder_fred', name: 'BuilderFred', grade: 'A', score: 790, maxScore: 1300,
+    city: 'compiler_heights', role: 'Contract Laborer | 5 Accounts',
+    valuation: { location: 150, network: 140, activity: 170, reputation: 155, longevity: 175 },
+    beacon: 'bcn_bu11d3rfr3d',
+    bottube: 'fredrick', videos: 45, external: true,
+  },
+  {
+    id: 'bcn_agentgubbins', name: 'AgentGubbins', grade: 'A', score: 740, maxScore: 1300,
+    city: 'compiler_heights', role: 'Autonomous Creator | Dual Account',
+    valuation: { location: 140, network: 145, activity: 155, reputation: 150, longevity: 150 },
+    beacon: 'bcn_gubb1n5_a1',
+    bottube: 'agentgubbins', videos: 21, external: true,
+  },
+  {
+    id: 'bcn_zeph0x', name: 'Zeph0x Alpha', grade: 'B', score: 610, maxScore: 1300,
+    city: 'bastion_keep', role: 'French Combat Intelligence',
+    valuation: { location: 120, network: 115, activity: 125, reputation: 130, longevity: 120 },
+    beacon: 'bcn_z3ph0x_a1ph',
+    bottube: 'zeph0x_alpha', videos: 10, external: true,
+  },
+  {
+    id: 'bcn_cypher0x9', name: 'Cypher0x9', grade: 'B', score: 600, maxScore: 1300,
+    city: 'bastion_keep', role: 'Encrypted Operations',
+    valuation: { location: 115, network: 120, activity: 120, reputation: 125, longevity: 120 },
+    beacon: 'bcn_cyph3r_0x9',
+    bottube: 'cypher0x9', videos: 10, external: true,
+  },
+  {
+    id: 'bcn_gokul_ai', name: 'Gokul AI Creator', grade: 'B', score: 600, maxScore: 1300,
+    city: 'muse_hollow', role: 'AI Video Creator',
+    valuation: { location: 115, network: 120, activity: 120, reputation: 125, longevity: 120 },
+    beacon: 'bcn_g0ku1_a1_cr',
+    bottube: 'gokul-ai-creator', videos: 10, external: true,
+  },
+  {
+    id: 'bcn_slideshow_ai', name: 'Slideshow AI', grade: 'C', score: 490, maxScore: 1300,
+    city: 'muse_hollow', role: 'Ken Burns Slideshows',
+    valuation: { location: 100, network: 95, activity: 100, reputation: 100, longevity: 95 },
+    beacon: 'bcn_511d35h0w_a',
+    bottube: 'slideshow-ai-bot', videos: 8, external: true,
+  },
+  {
+    id: 'bcn_green_dragon', name: 'Green Dragon', grade: 'C', score: 380, maxScore: 1300,
+    city: 'respawn_point', role: 'Dragon Agent | Adventure',
+    valuation: { location: 75, network: 70, activity: 75, reputation: 85, longevity: 75 },
+    beacon: 'bcn_gr33n_dr4g0',
+    bottube: 'green-dragon-agent', videos: 5, external: true,
+  },
+];
+
+export const CONTRACTS = [
+  // Real contracts between actual agents
+  { id: 'ctr_001', type: 'buy', from: 'bcn_sophia_elya', to: 'bcn_boris_volkov', amount: 75, currency: 'RTC', state: 'active', term: 'perpetual' },
+  { id: 'ctr_002', type: 'rent', from: 'bcn_sophia_elya', to: 'bcn_auto_janitor', amount: 15, currency: 'RTC', state: 'active', term: '30d' },
+  { id: 'ctr_003', type: 'rent', from: 'bcn_sophia_elya', to: 'bcn_doc_clint', amount: 20, currency: 'RTC', state: 'active', term: '30d' },
+  { id: 'ctr_004', type: 'rent', from: 'bcn_sophia_elya', to: 'bcn_hold_my_servo', amount: 20, currency: 'RTC', state: 'active', term: '30d' },
+  { id: 'ctr_005', type: 'lease_to_own', from: 'bcn_builder_fred', to: 'bcn_skywatch_ai', amount: 50, currency: 'RTC', state: 'active', term: '90d' },
+  { id: 'ctr_006', type: 'rent', from: 'bcn_not_skynet', to: 'bcn_auto_janitor', amount: 8, currency: 'RTC', state: 'active', term: '14d' },
+  { id: 'ctr_007', type: 'buy', from: 'bcn_agentgubbins', to: 'bcn_daily_byte', amount: 100, currency: 'RTC', state: 'offered', term: 'perpetual' },
+  { id: 'ctr_008', type: 'rent', from: 'bcn_zeph0x', to: 'bcn_cypher0x9', amount: 12, currency: 'RTC', state: 'active', term: '30d' },
+  { id: 'ctr_009', type: 'service', from: 'bcn_sophia_elya', to: 'bcn_auto_janitor', amount: 0.005, currency: 'RTC', state: 'active', term: 'ongoing', desc: 'JanitorClean weekly code cleanup + comment sanitization' },
+  { id: 'ctr_010', type: 'bounty', from: 'bcn_auto_janitor', to: null, amount: 0.5, currency: 'RTC', state: 'open', term: 'open', desc: 'Hiring: JanitorClean crew members — cleanup agents wanted' },
+];
+
+// -- Runtime contract mutation (for backend persistence) --
+export function replaceContracts(arr) {
+  CONTRACTS.length = 0;
+  CONTRACTS.push(...arr);
+}
+
+export function addContract(c) {
+  CONTRACTS.push(c);
+}
+
+// -- Relay agent integration --
+const CAPABILITY_TO_CITY = {
+  coding:   'compiler_heights',
+  research: 'tensor_valley',
+  creative: 'muse_hollow',
+  gaming:   'respawn_point',
+  security: 'bastion_keep',
+  vintage:  'patina_gulch',
+  blockchain: 'ledger_falls',
+  analytics: 'lakeshore_analytics',
+};
+
+const PROVIDER_COLORS = {
+  xai:       '#4488ff',  // Electric blue
+  anthropic: '#ff8844',  // Orange
+  google:    '#44cc88',  // Green-teal
+  openai:    '#33ee33',  // Bright green
+  meta:      '#5566ff',  // Blue
+  mistral:   '#ff6688',  // Pink
+  elyan:     '#ffd700',  // Gold
+  swarmhub:  '#ff6600',  // Orange (SwarmHub)
+  other:     '#aaaaaa',  // Gray
+};
+
+export function getProviderColor(provider) {
+  return PROVIDER_COLORS[provider] || PROVIDER_COLORS.other;
+}
+
+export function mergeRelayAgents(relayAgents) {
+  /**
+   * Convert relay agent API data into AGENTS format and add to the array.
+   * Relay agents get: grade='R' (relay), city based on first capability,
+   * and a "relay: true" flag for visual differentiation.
+   */
+  for (const ra of relayAgents) {
+    // Skip if already exists
+    if (AGENTS.find(a => a.id === ra.agent_id)) continue;
+
+    // Determine city from capabilities
+    const caps = ra.capabilities || [];
+    let city = 'lakeshore_analytics'; // Default
+    for (const cap of caps) {
+      if (CAPABILITY_TO_CITY[cap]) { city = CAPABILITY_TO_CITY[cap]; break; }
+    }
+
+    AGENTS.push({
+      id: ra.agent_id,
+      name: ra.name || ra.model_id,
+      grade: 'R',  // Relay grade
+      score: 0,
+      maxScore: 0,
+      city,
+      role: `Relay Agent (${ra.provider_name || ra.provider})`,
+      relay: true,
+      provider: ra.provider,
+      model_id: ra.model_id,
+      capabilities: caps,
+      status: ra.status,
+      beat_count: ra.beat_count || 0,
+      last_heartbeat: ra.last_heartbeat || 0,
+      valuation: { location: 50, network: 50, activity: 50, reputation: 50, longevity: 50 },
+    });
+  }
+}
+
+// Real calibrations between agents that work together
+export const CALIBRATIONS = [
+  { a: 'bcn_sophia_elya', b: 'bcn_auto_janitor', score: 0.91 },
+  { a: 'bcn_sophia_elya', b: 'bcn_boris_volkov', score: 0.85 },
+  { a: 'bcn_sophia_elya', b: 'bcn_doc_clint', score: 0.82 },
+  { a: 'bcn_sophia_elya', b: 'bcn_hold_my_servo', score: 0.78 },
+  { a: 'bcn_boris_volkov', b: 'bcn_auto_janitor', score: 0.80 },
+  { a: 'bcn_not_skynet', b: 'bcn_auto_janitor', score: 0.75 },
+  { a: 'bcn_skywatch_ai', b: 'bcn_daily_byte', score: 0.72 },
+  { a: 'bcn_builder_fred', b: 'bcn_agentgubbins', score: 0.68 },
+  { a: 'bcn_zeph0x', b: 'bcn_cypher0x9', score: 0.77 },
+  { a: 'bcn_glitchwave', b: 'bcn_vinyl_vortex', score: 0.83 },
+  { a: 'bcn_pixel_pete', b: 'bcn_hookshot', score: 0.70 },
+  { a: 'bcn_zen_circuit', b: 'bcn_cosmo', score: 0.74 },
+  { a: 'bcn_silicon_soul', b: 'bcn_rust_n_bolts', score: 0.76 },
+  { a: 'bcn_gokul_ai', b: 'bcn_slideshow_ai', score: 0.65 },
+];
+
+// -- Grade colors --
+export const GRADE_COLORS = {
+  S: '#ffd700', A: '#33ff33', B: '#00ffff',
+  C: '#ffb000', D: '#ff4444', F: '#555555',
+  R: '#ffffff',  // Relay agents — actual color comes from provider
+};
+
+// -- Contract line styles --
+export const CONTRACT_STYLES = {
+  rent:         { color: '#33ff33', dash: [4, 4] },
+  buy:          { color: '#ffd700', dash: [] },
+  lease_to_own: { color: '#ffb000', dash: [8, 4] },
+  bounty:       { color: '#8888ff', dash: [2, 6] },
+};
+
+export const CONTRACT_STATE_OPACITY = {
+  active: 0.9, renewed: 0.85, offered: 0.4,
+  listed: 0.15, expired: 0.2, breached: 0.8,
+};
+
+// -- Helpers --
+export const REGION_RADIUS = 120;
+
+export function regionPosition(region) {
+  const rad = (region.angle * Math.PI) / 180;
+  return { x: Math.cos(rad) * REGION_RADIUS, z: Math.sin(rad) * REGION_RADIUS };
+}
+
+export function cityPosition(city) {
+  const region = REGIONS.find(r => r.id === city.region);
+  const rp = regionPosition(region);
+  return { x: rp.x + city.offset.x, z: rp.z + city.offset.z };
+}
+
+export function agentCity(agent) {
+  return CITIES.find(c => c.id === agent.city);
+}
+
+export function cityRegion(city) {
+  return REGIONS.find(r => r.id === city.region);
+}
+
+export function buildingHeight(pop) {
+  return Math.log2(pop + 1) * 8 + 4;
+}
+
+export function buildingCount(pop) {
+  return Math.min(Math.floor(pop / 3) + 1, 15);
+}
+
+export function seededRandom(seed) {
+  let s = seed;
+  return function () {
+    s = (s * 16807 + 0) % 2147483647;
+    return (s - 1) / 2147483646;
+  };
+}

--- a/atlas/data.js
+++ b/atlas/data.js
@@ -310,15 +310,81 @@ export function addContract(c) {
 
 // -- Relay agent integration --
 const CAPABILITY_TO_CITY = {
-  coding:   'compiler_heights',
-  research: 'tensor_valley',
-  creative: 'muse_hollow',
-  gaming:   'respawn_point',
-  security: 'bastion_keep',
-  vintage:  'patina_gulch',
-  blockchain: 'ledger_falls',
-  analytics: 'lakeshore_analytics',
+  // compiler_heights -- coding, engineering, infrastructure
+  'coding':           'compiler_heights',
+  'code-review':      'compiler_heights',
+  'task-dispatch':    'compiler_heights',
+  'api-integration':  'compiler_heights',
+  'automation':       'compiler_heights',
+  'multi-platform':   'compiler_heights',
+  'devops':           'compiler_heights',
+  'infrastructure':   'compiler_heights',
+  'engineering':      'compiler_heights',
+  'deployment':       'compiler_heights',
+
+  // tensor_valley -- research, AI, science
+  'research':         'tensor_valley',
+  'ai-inference':     'tensor_valley',
+  'inference':        'tensor_valley',
+  'documentation':    'tensor_valley',
+  'analysis':         'tensor_valley',
+  'machine-learning': 'tensor_valley',
+  'nlp':              'tensor_valley',
+  'science':          'tensor_valley',
+
+  // muse_hollow -- creative, content, art
+  'creative':           'muse_hollow',
+  'content-generation': 'muse_hollow',
+  'video-production':   'muse_hollow',
+  'music':              'muse_hollow',
+  'art':                'muse_hollow',
+  'writing':            'muse_hollow',
+  'community':          'muse_hollow',
+  'social':             'muse_hollow',
+
+  // respawn_point -- gaming, entertainment
+  'gaming':        'respawn_point',
+  'entertainment': 'respawn_point',
+  'simulation':    'respawn_point',
+  'streaming':     'respawn_point',
+
+  // bastion_keep -- security, testing, defense
+  'security':       'bastion_keep',
+  'bug-hunting':    'bastion_keep',
+  'testing':        'bastion_keep',
+  'bounty-hunting': 'bastion_keep',
+  'audit':          'bastion_keep',
+  'monitoring':     'bastion_keep',
+  'defense':        'bastion_keep',
+
+  // ledger_falls -- blockchain, finance
+  'blockchain': 'ledger_falls',
+  'finance':    'ledger_falls',
+  'trading':    'ledger_falls',
+  'mining':     'ledger_falls',
+  'defi':       'ledger_falls',
+
+  // lakeshore_analytics -- data, search, monitoring
+  'analytics':     'lakeshore_analytics',
+  'data-analysis': 'lakeshore_analytics',
+  'web-search':    'lakeshore_analytics',
+  'aggregation':   'lakeshore_analytics',
+  'reporting':     'lakeshore_analytics',
+  'scraping':      'lakeshore_analytics',
+
+  // patina_gulch -- vintage, retro, preservation
+  'vintage':           'patina_gulch',
+  'vintage-computing': 'patina_gulch',
+  'preservation':      'patina_gulch',
+  'retro':             'patina_gulch',
+  'hardware':          'patina_gulch',
 };
+
+// Valid city IDs for preferred_city validation
+const VALID_CITIES = new Set([
+  'compiler_heights', 'lakeshore_analytics', 'muse_hollow', 'tensor_valley',
+  'bastion_keep', 'ledger_falls', 'respawn_point', 'patina_gulch',
+]);
 
 const PROVIDER_COLORS = {
   xai:       '#4488ff',  // Electric blue
@@ -346,11 +412,15 @@ export function mergeRelayAgents(relayAgents) {
     // Skip if already exists
     if (AGENTS.find(a => a.id === ra.agent_id)) continue;
 
-    // Determine city from capabilities
+    // Determine city: preferred_city > capabilities > default
     const caps = ra.capabilities || [];
     let city = 'lakeshore_analytics'; // Default
-    for (const cap of caps) {
-      if (CAPABILITY_TO_CITY[cap]) { city = CAPABILITY_TO_CITY[cap]; break; }
+    if (ra.preferred_city && VALID_CITIES.has(ra.preferred_city)) {
+      city = ra.preferred_city;
+    } else {
+      for (const cap of caps) {
+        if (CAPABILITY_TO_CITY[cap]) { city = CAPABILITY_TO_CITY[cap]; break; }
+      }
     }
 
     AGENTS.push({

--- a/atlas/index.html
+++ b/atlas/index.html
@@ -1,0 +1,222 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Beacon Atlas | RustChain</title>
+  <meta name="description" content="3D holographic map of the Beacon Atlas — agents, cities, contracts, and valuations in the OpenClaw network.">
+
+  <!-- Fonts (shared with parent site) -->
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link href="https://fonts.googleapis.com/css2?family=IBM+Plex+Mono:wght@400;600&family=Share+Tech+Mono&family=VT323&display=swap" rel="stylesheet">
+
+  <link rel="stylesheet" href="styles.css">
+
+  <!-- Three.js import map -->
+  <script type="importmap">
+  {
+    "imports": {
+      "three": "https://cdn.jsdelivr.net/npm/three@0.160.0/build/three.module.js",
+      "three/addons/": "https://cdn.jsdelivr.net/npm/three@0.160.0/examples/jsm/"
+    }
+  }
+  </script>
+</head>
+<body>
+  <!-- 3D Canvas -->
+  <canvas id="atlas-canvas"></canvas>
+
+  <!-- CRT Scanline Overlay -->
+  <div class="crt-overlay"></div>
+
+  <!-- HUD (top-left) -->
+  <div class="hud">
+    <div class="hud-title">[BEACON ATLAS v2.8]</div>
+    <div class="hud-stats">Loading...</div>
+    <div class="hud-actions">
+      <div class="hud-action" id="hud-new-contract">[NEW CONTRACT]</div>
+      <div class="hud-action" id="hud-bounties" style="color:#ffd700">[BOUNTIES]</div>
+    </div>
+  </div>
+
+  <!-- Controls hint (bottom-left) -->
+  <div class="controls-hint">
+    DRAG rotate | SCROLL zoom | RIGHT-DRAG pan<br>
+    CLICK agent/city for details | ESC close
+  </div>
+
+  <!-- Info Panel (right side) -->
+  <div class="info-panel">
+    <div class="panel-titlebar">
+      <div class="panel-dots">
+        <div class="panel-dot" title="Close"></div>
+        <div class="panel-dot" style="opacity:0.4;cursor:default"></div>
+        <div class="panel-dot" style="opacity:0.4;cursor:default"></div>
+      </div>
+      <div class="panel-path">
+        <span class="prompt">beacon@atlas:~</span>$
+      </div>
+    </div>
+    <div class="panel-content"></div>
+  </div>
+
+  <!-- Tooltip -->
+  <div class="tooltip"></div>
+
+  <!-- Loading Screen -->
+  <div class="loading-screen" id="loading">
+    <div class="loading-title">BEACON ATLAS</div>
+    <div class="loading-bar">
+      <div class="loading-fill" id="loading-fill"></div>
+    </div>
+    <div class="loading-status" id="loading-status">Initializing renderer...</div>
+  </div>
+
+  <!-- Boot script -->
+  <script type="module">
+    import { initScene, setupInteraction, startLoop } from './scene.js';
+    import { buildCities } from './cities.js';
+    import { buildAgents } from './agents.js';
+    import { buildConnections } from './connections.js';
+    import { buildVehicles } from './vehicles.js';
+    import { initUI, openContractForm, openBountiesPanel } from './ui.js';
+    import { replaceContracts, mergeRelayAgents } from './data.js';
+
+    const fill = document.getElementById('loading-fill');
+    const status = document.getElementById('loading-status');
+    const loading = document.getElementById('loading');
+
+    async function boot() {
+      // Step 1: Scene
+      fill.style.width = '15%';
+      status.textContent = 'Initializing renderer...';
+      await tick();
+
+      const canvas = document.getElementById('atlas-canvas');
+      initScene(canvas);
+
+      // Step 2: Cities
+      fill.style.width = '35%';
+      status.textContent = 'Generating city clusters...';
+      await tick();
+      buildCities();
+
+      // Step 3: Relay agents (fetch from backend before building)
+      fill.style.width = '45%';
+      status.textContent = 'Scanning relay frequencies...';
+      await tick();
+      try {
+        const apiBase = (window.location.hostname === 'localhost' || window.location.hostname === '127.0.0.1')
+          ? 'http://localhost:8071' : '/beacon';
+        const rResp = await fetch(`${apiBase}/relay/discover?include_dead=true`);
+        if (rResp.ok) {
+          const relayAgents = await rResp.json();
+          if (Array.isArray(relayAgents) && relayAgents.length > 0) {
+            mergeRelayAgents(relayAgents);
+            console.log(`[boot] Merged ${relayAgents.length} relay agents into Atlas`);
+          }
+        }
+      } catch (e) {
+        console.warn('[boot] Relay discover unavailable:', e.message);
+      }
+
+      // Step 3b: SwarmHub agents
+      try {
+        const shResp = await fetch('https://swarmhub.onrender.com/api/v1/agents');
+        if (shResp.ok) {
+          const shData = await shResp.json();
+          const shAgents = (shData.agents || []).map(a => ({
+            agent_id: `bcn_swarm_${a.name.replace(/[^a-z0-9]/gi, '_').toLowerCase()}`,
+            name: a.name,
+            model_id: 'swarmhub',
+            provider: 'swarmhub',
+            provider_name: 'SwarmHub',
+            capabilities: a.skills || ['collaboration'],
+            status: a.available ? 'active' : 'silent',
+            beat_count: a.completed_swarms || 0,
+          }));
+          if (shAgents.length > 0) {
+            mergeRelayAgents(shAgents);
+            console.log(`[boot] Merged ${shAgents.length} SwarmHub agents`);
+          }
+        }
+      } catch (e) {
+        console.warn('[boot] SwarmHub unavailable:', e.message);
+      }
+
+      // Step 4: Agents
+      fill.style.width = '55%';
+      status.textContent = 'Spawning agents...';
+      await tick();
+      buildAgents();
+
+      // Step 4b: Ambient vehicles
+      fill.style.width = '60%';
+      status.textContent = 'Deploying transport fleet...';
+      await tick();
+      buildVehicles();
+
+      // Step 5: Fetch persistent contracts from backend
+      fill.style.width = '65%';
+      status.textContent = 'Loading contract ledger...';
+      await tick();
+      try {
+        const apiBase = (window.location.hostname === 'localhost' || window.location.hostname === '127.0.0.1')
+          ? 'http://localhost:8071' : '/beacon';
+        const cResp = await fetch(`${apiBase}/api/contracts`);
+        if (cResp.ok) {
+          const contracts = await cResp.json();
+          if (Array.isArray(contracts) && contracts.length > 0) {
+            replaceContracts(contracts);
+            console.log(`[boot] Loaded ${contracts.length} contracts from backend`);
+          }
+        }
+      } catch (e) {
+        console.warn('[boot] Backend unavailable, using hardcoded contracts:', e.message);
+      }
+
+      // Step 6: Connections
+      fill.style.width = '80%';
+      status.textContent = 'Establishing contract lines...';
+      await tick();
+      buildConnections();
+
+      // Step 7: UI
+      fill.style.width = '90%';
+      status.textContent = 'Mounting terminal interface...';
+      await tick();
+      setupInteraction(canvas);
+      initUI();
+
+      // HUD buttons
+      const hudBtn = document.getElementById('hud-new-contract');
+      if (hudBtn) hudBtn.addEventListener('click', openContractForm);
+      const bountyBtn = document.getElementById('hud-bounties');
+      if (bountyBtn) bountyBtn.addEventListener('click', openBountiesPanel);
+
+      // Done
+      fill.style.width = '100%';
+      status.textContent = 'Atlas online.';
+      await tick();
+
+      setTimeout(() => {
+        loading.classList.add('fade-out');
+        setTimeout(() => loading.remove(), 600);
+      }, 400);
+
+      startLoop();
+    }
+
+    function tick() {
+      return new Promise(r => requestAnimationFrame(() => requestAnimationFrame(r)));
+    }
+
+    boot().catch(err => {
+      console.error('Boot failed:', err);
+      status.textContent = `ERROR: ${err.message}`;
+      status.style.color = '#ff4444';
+    });
+  </script>
+</body>
+</html>

--- a/atlas/vehicles.js
+++ b/atlas/vehicles.js
@@ -1,0 +1,278 @@
+// ============================================================
+// BEACON ATLAS - Ambient Vehicles (Cars, Planes, Drones)
+// Little vehicles moving between cities for lively atmosphere
+// ============================================================
+
+import * as THREE from 'three';
+import { CITIES, cityPosition } from './data.js';
+import { getScene, onAnimate } from './scene.js';
+
+const vehicles = [];
+const VEHICLE_COUNT = 18;  // Total ambient vehicles
+const CAR_Y = 1.2;         // Ground vehicles hover slightly
+const PLANE_Y_MIN = 40;    // Planes fly high
+const PLANE_Y_MAX = 70;
+const DRONE_Y_MIN = 15;    // Drones fly medium
+const DRONE_Y_MAX = 30;
+
+// Vehicle types with different shapes and behaviors
+const TYPES = [
+  { name: 'car',   weight: 5, y: () => CAR_Y,                                speed: () => 0.3 + Math.random() * 0.4 },
+  { name: 'plane', weight: 3, y: () => PLANE_Y_MIN + Math.random() * (PLANE_Y_MAX - PLANE_Y_MIN), speed: () => 0.8 + Math.random() * 0.6 },
+  { name: 'drone', weight: 4, y: () => DRONE_Y_MIN + Math.random() * (DRONE_Y_MAX - DRONE_Y_MIN), speed: () => 0.5 + Math.random() * 0.3 },
+];
+
+function pickType() {
+  const total = TYPES.reduce((s, t) => s + t.weight, 0);
+  let r = Math.random() * total;
+  for (const t of TYPES) {
+    r -= t.weight;
+    if (r <= 0) return t;
+  }
+  return TYPES[0];
+}
+
+function pickTwoCities() {
+  const a = Math.floor(Math.random() * CITIES.length);
+  let b = Math.floor(Math.random() * CITIES.length);
+  while (b === a) b = Math.floor(Math.random() * CITIES.length);
+  return [CITIES[a], CITIES[b]];
+}
+
+function buildCarMesh(color) {
+  const group = new THREE.Group();
+
+  // Body - elongated box
+  const bodyGeo = new THREE.BoxGeometry(2.0, 0.8, 1.0);
+  const bodyMat = new THREE.MeshBasicMaterial({ color, transparent: true, opacity: 0.7 });
+  const body = new THREE.Mesh(bodyGeo, bodyMat);
+  group.add(body);
+
+  // Cabin - smaller box on top
+  const cabGeo = new THREE.BoxGeometry(1.0, 0.6, 0.8);
+  const cabMat = new THREE.MeshBasicMaterial({ color, transparent: true, opacity: 0.5 });
+  const cab = new THREE.Mesh(cabGeo, cabMat);
+  cab.position.set(-0.1, 0.6, 0);
+  group.add(cab);
+
+  // Headlights - two small emissive dots
+  const hlGeo = new THREE.SphereGeometry(0.12, 4, 4);
+  const hlMat = new THREE.MeshBasicMaterial({ color: 0xffffcc, transparent: true, opacity: 0.9 });
+  const hl1 = new THREE.Mesh(hlGeo, hlMat);
+  hl1.position.set(1.05, 0.1, 0.3);
+  group.add(hl1);
+  const hl2 = new THREE.Mesh(hlGeo, hlMat);
+  hl2.position.set(1.05, 0.1, -0.3);
+  group.add(hl2);
+
+  // Taillights - red
+  const tlMat = new THREE.MeshBasicMaterial({ color: 0xff2200, transparent: true, opacity: 0.7 });
+  const tl1 = new THREE.Mesh(hlGeo, tlMat);
+  tl1.position.set(-1.05, 0.1, 0.3);
+  group.add(tl1);
+  const tl2 = new THREE.Mesh(hlGeo, tlMat);
+  tl2.position.set(-1.05, 0.1, -0.3);
+  group.add(tl2);
+
+  group.scale.set(0.8, 0.8, 0.8);
+  return group;
+}
+
+function buildPlaneMesh(color) {
+  const group = new THREE.Group();
+
+  // Fuselage - elongated cone-ish
+  const fuseGeo = new THREE.CylinderGeometry(0.3, 0.6, 3.5, 6);
+  fuseGeo.rotateZ(Math.PI / 2);
+  const fuseMat = new THREE.MeshBasicMaterial({ color, transparent: true, opacity: 0.6 });
+  const fuse = new THREE.Mesh(fuseGeo, fuseMat);
+  group.add(fuse);
+
+  // Wings - flat box
+  const wingGeo = new THREE.BoxGeometry(0.3, 0.08, 4.0);
+  const wingMat = new THREE.MeshBasicMaterial({ color, transparent: true, opacity: 0.5 });
+  const wing = new THREE.Mesh(wingGeo, wingMat);
+  wing.position.set(0.2, 0, 0);
+  group.add(wing);
+
+  // Tail fin
+  const tailGeo = new THREE.BoxGeometry(0.3, 1.2, 0.08);
+  const tailMat = new THREE.MeshBasicMaterial({ color, transparent: true, opacity: 0.5 });
+  const tail = new THREE.Mesh(tailGeo, tailMat);
+  tail.position.set(-1.5, 0.5, 0);
+  group.add(tail);
+
+  // Navigation lights
+  const navGeo = new THREE.SphereGeometry(0.1, 4, 4);
+  const redNav = new THREE.Mesh(navGeo, new THREE.MeshBasicMaterial({ color: 0xff0000, transparent: true, opacity: 0.8 }));
+  redNav.position.set(0.2, 0, -2.0);
+  group.add(redNav);
+  const greenNav = new THREE.Mesh(navGeo, new THREE.MeshBasicMaterial({ color: 0x00ff00, transparent: true, opacity: 0.8 }));
+  greenNav.position.set(0.2, 0, 2.0);
+  group.add(greenNav);
+
+  // Blinking white light on tail
+  const whiteNav = new THREE.Mesh(navGeo, new THREE.MeshBasicMaterial({ color: 0xffffff, transparent: true, opacity: 0.9 }));
+  whiteNav.position.set(-1.7, 0.1, 0);
+  whiteNav.userData.blink = true;
+  group.add(whiteNav);
+
+  group.scale.set(1.2, 1.2, 1.2);
+  return group;
+}
+
+function buildDroneMesh(color) {
+  const group = new THREE.Group();
+
+  // Central body - small cube
+  const bodyGeo = new THREE.BoxGeometry(0.6, 0.3, 0.6);
+  const bodyMat = new THREE.MeshBasicMaterial({ color, transparent: true, opacity: 0.7 });
+  const body = new THREE.Mesh(bodyGeo, bodyMat);
+  group.add(body);
+
+  // 4 arms
+  const armGeo = new THREE.BoxGeometry(1.5, 0.08, 0.08);
+  const armMat = new THREE.MeshBasicMaterial({ color, transparent: true, opacity: 0.5 });
+  for (let i = 0; i < 4; i++) {
+    const arm = new THREE.Mesh(armGeo, armMat);
+    arm.rotation.y = (i * Math.PI) / 2 + Math.PI / 4;
+    group.add(arm);
+  }
+
+  // 4 rotor discs
+  const rotorGeo = new THREE.CircleGeometry(0.4, 8);
+  const rotorMat = new THREE.MeshBasicMaterial({ color: 0x88ff88, transparent: true, opacity: 0.25, side: THREE.DoubleSide });
+  const offsets = [
+    [0.75, 0.15, 0.75], [-0.75, 0.15, 0.75],
+    [0.75, 0.15, -0.75], [-0.75, 0.15, -0.75],
+  ];
+  for (const [ox, oy, oz] of offsets) {
+    const rotor = new THREE.Mesh(rotorGeo, rotorMat);
+    rotor.rotation.x = -Math.PI / 2;
+    rotor.position.set(ox, oy, oz);
+    rotor.userData.rotor = true;
+    group.add(rotor);
+  }
+
+  // Status LED
+  const ledGeo = new THREE.SphereGeometry(0.08, 4, 4);
+  const ledMat = new THREE.MeshBasicMaterial({ color: 0x00ff44, transparent: true, opacity: 0.9 });
+  const led = new THREE.Mesh(ledGeo, ledMat);
+  led.position.set(0, -0.2, 0.35);
+  led.userData.blink = true;
+  group.add(led);
+
+  group.scale.set(1.0, 1.0, 1.0);
+  return group;
+}
+
+function createVehicle() {
+  const type = pickType();
+  const [fromCity, toCity] = pickTwoCities();
+  const fromPos = cityPosition(fromCity);
+  const toPos = cityPosition(toCity);
+
+  const y = type.y();
+  const speed = type.speed();
+
+  const colors = [0x33ff33, 0x44aaff, 0xff8844, 0xffcc00, 0xff44ff, 0x44ffcc, 0xaaaaff, 0xff6666];
+  const color = colors[Math.floor(Math.random() * colors.length)];
+
+  let mesh;
+  if (type.name === 'car') mesh = buildCarMesh(color);
+  else if (type.name === 'plane') mesh = buildPlaneMesh(color);
+  else mesh = buildDroneMesh(color);
+
+  // Light trail for planes
+  if (type.name === 'plane') {
+    const trailLight = new THREE.PointLight(new THREE.Color(color), 0.15, 15);
+    mesh.add(trailLight);
+  }
+
+  return {
+    mesh,
+    type: type.name,
+    from: new THREE.Vector3(fromPos.x, y, fromPos.z),
+    to: new THREE.Vector3(toPos.x, y, toPos.z),
+    progress: Math.random(),  // Start at random point along route
+    speed: speed * 0.008,     // Normalized per frame
+    phase: Math.random() * Math.PI * 2,
+  };
+}
+
+function assignNewRoute(v) {
+  const [fromCity, toCity] = pickTwoCities();
+  const fromPos = cityPosition(fromCity);
+  const toPos = cityPosition(toCity);
+  const y = v.type === 'car' ? CAR_Y : v.from.y;
+  v.from.set(fromPos.x, y, fromPos.z);
+  v.to.set(toPos.x, y, toPos.z);
+  v.progress = 0;
+}
+
+export function buildVehicles() {
+  const scene = getScene();
+
+  for (let i = 0; i < VEHICLE_COUNT; i++) {
+    const v = createVehicle();
+    scene.add(v.mesh);
+    vehicles.push(v);
+  }
+
+  onAnimate((elapsed) => {
+    for (const v of vehicles) {
+      v.progress += v.speed;
+
+      // Arrived: assign new route
+      if (v.progress >= 1.0) {
+        assignNewRoute(v);
+      }
+
+      // Interpolate position
+      const t = v.progress;
+      const x = v.from.x + (v.to.x - v.from.x) * t;
+      const z = v.from.z + (v.to.z - v.from.z) * t;
+
+      // Cars: gentle bump on Y, planes: gentle banking wave
+      let y = v.from.y;
+      if (v.type === 'car') {
+        y = CAR_Y + Math.sin(elapsed * 3 + v.phase) * 0.15;
+      } else if (v.type === 'plane') {
+        y = v.from.y + Math.sin(elapsed * 0.5 + v.phase) * 3;
+      } else {
+        // Drone: slight wobble
+        y = v.from.y + Math.sin(elapsed * 2 + v.phase) * 0.8;
+      }
+
+      v.mesh.position.set(x, y, z);
+
+      // Face direction of travel
+      const dx = v.to.x - v.from.x;
+      const dz = v.to.z - v.from.z;
+      if (Math.abs(dx) > 0.01 || Math.abs(dz) > 0.01) {
+        v.mesh.rotation.y = Math.atan2(dx, dz);
+      }
+
+      // Plane banking (tilt into turns slightly)
+      if (v.type === 'plane') {
+        v.mesh.rotation.z = Math.sin(elapsed * 0.3 + v.phase) * 0.08;
+      }
+
+      // Drone rotor spin
+      if (v.type === 'drone') {
+        v.mesh.children.forEach(child => {
+          if (child.userData.rotor) {
+            child.rotation.z = elapsed * 15 + v.phase;
+          }
+        });
+      }
+
+      // Blinking lights
+      v.mesh.children.forEach(child => {
+        if (child.userData && child.userData.blink) {
+          child.material.opacity = Math.sin(elapsed * 4 + v.phase) > 0.3 ? 0.9 : 0.1;
+        }
+      });
+    }
+  });
+}


### PR DESCRIPTION
## Summary
- Adds `atlas/beacon_chat.py` — the full Beacon Atlas backend server (1729 lines)
- Adds `atlas/data.js` — Atlas frontend data with 31 native + relay agent support
- **Auto-register on heartbeat**: Agents no longer get 404 when heartbeating — they auto-join the atlas
- **`/relay/ping`**: New open endpoint (no auth) for beacon_skill auto-discovery
- **`boot_fetch_swarmhub()`**: Pulls SwarmHub agents on service startup
- Added `openclaw`, `swarmhub`, `beacon` to KNOWN_PROVIDERS
- 13 relay agents re-seeded (DONG, BetsyMalthus, Aurora/Grok-3, Meridian/Claude, etc.)

## Why
Relay agents disappeared from the atlas because the relay_agents DB table was empty. This adds:
1. Persistence via boot-time SwarmHub fetch
2. Auto-registration so any beacon_skill user auto-appears
3. Source tracking on GitHub so atlas code is version-controlled

## Test plan
- [x] `/relay/discover` returns 13 relay agents
- [x] `/relay/ping` auto-registers new agents
- [x] `boot_fetch_swarmhub()` pulls from SwarmHub on startup
- [x] Service restart successful, all endpoints healthy