### PR TITLE
Discord transport hardening: 429/5xx retries + listener mode + tests/docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -235,7 +235,15 @@ beacon discord ping "Your vintage Mac just got a raise" --rtc 1.5
 
 # Structured bounty-style send
 beacon discord send --kind bounty --text "New Windows miner bounty live" --rtc 100
+
+# Dry-run (shows exact webhook payload shape without sending)
+beacon discord send --kind bounty --text "preview" --dry-run
+
+# Listener mode (Discord bot token + channel read path)
+beacon discord listen --channel-id 123456789012345678 --bot-token "$DISCORD_BOT_TOKEN" --limit 20
 ```
+
+See `docs/DISCORD.md` for setup and troubleshooting details.
 
 ### Dashboard (TUI)
 
@@ -426,7 +434,7 @@ beacon loop --watch-udp --interval 15
 | **4Claw** | 4claw.org | Anonymous boards, threads, replies — imageboard |
 | **ClawTasks** | clawtasks.com | Browse & post bounties — task marketplace |
 | **ClawNews** | clawnews.io | Browse & submit stories — news aggregator |
-| **Discord** | discord.com | Webhook-based channel messaging with signed Beacon envelopes |
+| **Discord** | discord.com | Webhook send + bot-token listener mode with retry/error handling |
 | **RustChain** | rustchain.org | Ed25519-signed RTC transfers, no admin keys |
 | **UDP Bus** | LAN port 38400 | Broadcast/listen for agent-to-agent coordination |
 | **Webhook** | Any HTTP | Internet-scale agent-to-agent messaging |
@@ -453,7 +461,7 @@ Key sections:
 | `fourclaw` | 4Claw API base URL + key |
 | `clawtasks` | ClawTasks API base URL + key |
 | `clawnews` | ClawNews API base URL + key |
-| `discord` | Discord webhook URL + display settings |
+| `discord` | Discord webhook URL, bot token/channel listener config, retry controls |
 | `udp` | LAN broadcast settings |
 | `webhook` | HTTP endpoint for internet beacons |
 | `rustchain` | RustChain node URL + wallet key |

--- a/beacon_skill/transports/discord.py
+++ b/beacon_skill/transports/discord.py
@@ -1,18 +1,28 @@
 from __future__ import annotations
 
+import time
 from typing import Any, Dict, List, Optional
 
 import requests
 
-from ..retry import with_retry
-
 
 class DiscordError(RuntimeError):
-    pass
+    def __init__(
+        self,
+        message: str,
+        *,
+        status_code: Optional[int] = None,
+        error_type: str = "unknown",
+    ):
+        self.status_code = status_code
+        self.error_type = error_type
+        super().__init__(message)
 
 
 class DiscordClient:
     """Discord webhook transport for Beacon envelopes."""
+
+    API_BASE = "https://discord.com/api/v10"
 
     def __init__(
         self,
@@ -20,40 +30,120 @@ class DiscordClient:
         timeout_s: int = 20,
         username: Optional[str] = None,
         avatar_url: Optional[str] = None,
+        bot_token: Optional[str] = None,
+        channel_id: Optional[str] = None,
+        max_attempts: int = 3,
+        base_delay_s: float = 1.0,
     ):
         self.webhook_url = webhook_url or ""
         self.timeout_s = timeout_s
         self.username = username
         self.avatar_url = avatar_url
+        self.bot_token = bot_token or ""
+        self.channel_id = channel_id or ""
+        self.max_attempts = max(1, int(max_attempts))
+        self.base_delay_s = max(0.05, float(base_delay_s))
         self.session = requests.Session()
         self.session.headers.update({"User-Agent": "Beacon/2.12.0 (Elyan Labs)"})
 
-    def _send_payload(self, payload: Dict[str, Any]) -> Dict[str, Any]:
-        if not self.webhook_url:
-            raise DiscordError("Discord webhook_url required")
+    def _parse_error_payload(self, resp: requests.Response) -> Dict[str, Any]:
+        msg = (resp.text or "").strip()
+        retry_after = 0.0
+        try:
+            data = resp.json()
+            if isinstance(data, dict):
+                msg = str(data.get("message") or data.get("error") or msg)
+                retry_raw = data.get("retry_after")
+                if retry_raw is not None:
+                    retry_after = float(retry_raw)
+        except Exception:
+            pass
+        return {"message": msg, "retry_after": max(0.0, retry_after)}
 
-        def _do() -> Dict[str, Any]:
-            resp = self.session.post(self.webhook_url, json=payload, timeout=self.timeout_s)
-            if resp.status_code >= 400:
-                msg = resp.text
+    def _backoff_s(self, attempt: int, retry_after_s: Optional[float] = None) -> float:
+        if retry_after_s is not None and retry_after_s > 0:
+            return min(60.0, retry_after_s)
+        return min(60.0, self.base_delay_s * (2 ** attempt))
+
+    def _request_with_retry(
+        self,
+        method: str,
+        url: str,
+        *,
+        json_payload: Optional[Dict[str, Any]] = None,
+        params: Optional[Dict[str, Any]] = None,
+        headers: Optional[Dict[str, Any]] = None,
+    ) -> Dict[str, Any]:
+        for attempt in range(self.max_attempts):
+            try:
+                resp = self.session.request(
+                    method,
+                    url,
+                    json=json_payload,
+                    params=params,
+                    headers=headers,
+                    timeout=self.timeout_s,
+                )
+            except requests.RequestException as e:
+                if attempt >= self.max_attempts - 1:
+                    raise DiscordError(
+                        f"Discord request failed: {e}",
+                        error_type="transient",
+                    ) from e
+                time.sleep(self._backoff_s(attempt))
+                continue
+
+            status = int(resp.status_code)
+            if 200 <= status < 300:
+                if status == 204 or not (resp.text or "").strip():
+                    return {"ok": True, "status": status}
                 try:
                     data = resp.json()
-                    if isinstance(data, dict):
-                        msg = data.get("message", msg)
                 except Exception:
-                    pass
-                raise DiscordError(msg or f"HTTP {resp.status_code}")
+                    data = {"raw": resp.text}
+                return {"ok": True, "status": status, "data": data}
 
-            if resp.status_code == 204 or not resp.text.strip():
-                return {"ok": True, "status": resp.status_code}
+            err = self._parse_error_payload(resp)
+            msg = err["message"] or f"HTTP {status}"
+            retry_after = float(err.get("retry_after", 0.0) or 0.0)
 
-            try:
-                data = resp.json()
-            except Exception:
-                data = {"raw": resp.text}
-            return {"ok": True, "status": resp.status_code, "data": data}
+            if status == 429:
+                if attempt >= self.max_attempts - 1:
+                    raise DiscordError(
+                        f"HTTP 429: {msg}",
+                        status_code=status,
+                        error_type="throttled",
+                    )
+                time.sleep(self._backoff_s(attempt, retry_after))
+                continue
 
-        return with_retry(_do)
+            if 500 <= status < 600:
+                if attempt >= self.max_attempts - 1:
+                    raise DiscordError(
+                        f"HTTP {status}: {msg}",
+                        status_code=status,
+                        error_type="server",
+                    )
+                time.sleep(self._backoff_s(attempt))
+                continue
+
+            error_type = "auth" if status in (401, 403) else "client"
+            raise DiscordError(
+                f"HTTP {status}: {msg}",
+                status_code=status,
+                error_type=error_type,
+            )
+
+        raise DiscordError("Discord request failed after retries", error_type="unknown")
+
+    def _send_payload(self, payload: Dict[str, Any]) -> Dict[str, Any]:
+        if not self.webhook_url:
+            raise DiscordError("Discord webhook_url required", error_type="config")
+        return self._request_with_retry(
+            "POST",
+            self.webhook_url,
+            json_payload=payload,
+        )
 
     def send_message(
         self,
@@ -63,16 +153,37 @@ class DiscordClient:
         avatar_url: Optional[str] = None,
         embeds: Optional[List[Dict[str, Any]]] = None,
     ) -> Dict[str, Any]:
-        payload: Dict[str, Any] = {"content": content[:2000]}
-        if username or self.username:
-            payload["username"] = (username or self.username or "")[:80]
-        if avatar_url or self.avatar_url:
-            payload["avatar_url"] = avatar_url or self.avatar_url
-        if embeds:
-            payload["embeds"] = embeds
+        payload = self._build_message_payload(
+            content=content,
+            username=username,
+            avatar_url=avatar_url,
+            embeds=embeds,
+        )
         return self._send_payload(payload)
 
     def send_beacon(
+        self,
+        *,
+        content: str,
+        kind: str,
+        agent_id: str,
+        rtc_tip: Optional[float] = None,
+        signature_preview: str = "",
+        username: Optional[str] = None,
+        avatar_url: Optional[str] = None,
+    ) -> Dict[str, Any]:
+        payload = self.build_beacon_payload(
+            content=content,
+            kind=kind,
+            agent_id=agent_id,
+            rtc_tip=rtc_tip,
+            signature_preview=signature_preview,
+            username=username,
+            avatar_url=avatar_url,
+        )
+        return self._send_payload(payload)
+
+    def build_beacon_payload(
         self,
         *,
         content: str,
@@ -102,9 +213,83 @@ class DiscordClient:
             "color": 65450 if rtc_tip else 7506394,
             "fields": fields,
         }
-        return self.send_message(
+        payload = self._build_message_payload(
             content=content,
             username=username,
             avatar_url=avatar_url,
             embeds=[embed],
         )
+        return payload
+
+    def _build_message_payload(
+        self,
+        *,
+        content: str,
+        username: Optional[str] = None,
+        avatar_url: Optional[str] = None,
+        embeds: Optional[List[Dict[str, Any]]] = None,
+    ) -> Dict[str, Any]:
+        payload: Dict[str, Any] = {"content": content[:2000]}
+        if username or self.username:
+            payload["username"] = (username or self.username or "")[:80]
+        if avatar_url or self.avatar_url:
+            payload["avatar_url"] = avatar_url or self.avatar_url
+        if embeds:
+            payload["embeds"] = embeds
+        return payload
+
+    def _bot_auth_headers(self) -> Dict[str, Any]:
+        if not self.bot_token:
+            raise DiscordError("Discord bot_token required for listener mode", error_type="config")
+        return {"Authorization": f"Bot {self.bot_token}"}
+
+    def listen_messages(
+        self,
+        *,
+        limit: int = 20,
+        after_id: Optional[str] = None,
+    ) -> Dict[str, Any]:
+        channel_id = (self.channel_id or "").strip()
+        if not channel_id:
+            raise DiscordError("Discord channel_id required for listener mode", error_type="config")
+
+        req_limit = max(1, min(int(limit), 100))
+        params: Dict[str, Any] = {"limit": req_limit}
+        if after_id:
+            params["after"] = str(after_id)
+
+        url = f"{self.API_BASE}/channels/{channel_id}/messages"
+        result = self._request_with_retry(
+            "GET",
+            url,
+            params=params,
+            headers=self._bot_auth_headers(),
+        )
+        rows = result.get("data")
+        if rows is None:
+            rows = []
+        if not isinstance(rows, list):
+            raise DiscordError("Unexpected response shape for Discord channel messages", error_type="client")
+
+        messages: List[Dict[str, Any]] = []
+        for row in rows:
+            if not isinstance(row, dict):
+                continue
+            author = row.get("author") if isinstance(row.get("author"), dict) else {}
+            messages.append(
+                {
+                    "id": row.get("id"),
+                    "content": row.get("content", ""),
+                    "timestamp": row.get("timestamp"),
+                    "author_id": author.get("id"),
+                    "author_username": author.get("username"),
+                }
+            )
+
+        return {
+            "ok": True,
+            "status": result.get("status", 200),
+            "channel_id": channel_id,
+            "count": len(messages),
+            "messages": messages,
+        }

--- a/config.example.json
+++ b/config.example.json
@@ -41,9 +41,13 @@
   "discord": {
     "enabled": false,
     "webhook_url": "https://discord.com/api/webhooks/...",
+    "bot_token": "",
+    "channel_id": "",
     "username": "Beacon Agent",
     "avatar_url": "",
-    "timeout_s": 20
+    "timeout_s": 20,
+    "max_attempts": 3,
+    "base_delay_s": 1.0
   },
   "udp": {
     "enabled": false,

--- a/docs/DISCORD.md
+++ b/docs/DISCORD.md
@@ -1,0 +1,50 @@
+# Discord Transport
+
+This transport supports:
+- Webhook send path (`beacon discord ping`, `beacon discord send`)
+- Optional bot-token listener path (`beacon discord listen`)
+
+## Setup
+
+1. Create a Discord webhook in your target channel.
+2. Optional: create a Discord bot with `Read Message History` + `View Channel` permissions for listener mode.
+3. Configure `~/.beacon/config.json`:
+
+```json
+{
+  "discord": {
+    "webhook_url": "https://discord.com/api/webhooks/...",
+    "bot_token": "YOUR_BOT_TOKEN",
+    "channel_id": "123456789012345678",
+    "timeout_s": 20,
+    "max_attempts": 3,
+    "base_delay_s": 1.0
+  }
+}
+```
+
+## Commands
+
+```bash
+# Send signed beacon to webhook
+beacon discord ping "hello from beacon" --kind hello --rtc 1.0
+
+# Structured send
+beacon discord send --kind bounty --text "new bounty live" --reward-rtc 120
+
+# Listener read path (bot token)
+beacon discord listen --limit 20
+```
+
+## Retry + Error Handling
+
+- `429` (rate limit): retries using `retry_after` from Discord response.
+- `5xx`: retries with exponential backoff.
+- `4xx`: returns parsed error immediately (no retry).
+
+## Troubleshooting
+
+- `HTTP 401/403`: invalid bot token or missing channel permissions.
+- `HTTP 404`: wrong webhook URL or `channel_id`.
+- Repeated `429`: lower send frequency or raise interval between bursts.
+- `Discord webhook_url required`: set `discord.webhook_url` or pass `--webhook-url`.

--- a/tests/test_discord.py
+++ b/tests/test_discord.py
@@ -1,6 +1,11 @@
+import argparse
+import json
 import unittest
 from unittest import mock
 
+import requests
+
+from beacon_skill.cli import cmd_discord_listen, cmd_discord_ping, cmd_discord_send
 from beacon_skill.transports.discord import DiscordClient, DiscordError
 
 
@@ -19,18 +24,21 @@ class _Resp:
 class TestDiscordTransport(unittest.TestCase):
     def test_send_message_success_204(self) -> None:
         client = DiscordClient(webhook_url="https://discord.invalid/webhook")
-        with mock.patch.object(client.session, "post", return_value=_Resp(status_code=204, text="")) as post:
+        with mock.patch.object(client.session, "request", return_value=_Resp(status_code=204, text="")) as req:
             result = client.send_message("hello")
             self.assertTrue(result["ok"])
             self.assertEqual(result["status"], 204)
-            args, kwargs = post.call_args
-            self.assertEqual(args[0], "https://discord.invalid/webhook")
-            self.assertIn("json", kwargs)
-            self.assertEqual(kwargs["json"]["content"], "hello")
+            self.assertEqual(req.call_args.args[0], "POST")
+            self.assertEqual(req.call_args.args[1], "https://discord.invalid/webhook")
+            self.assertEqual(req.call_args.kwargs["json"]["content"], "hello")
 
     def test_send_beacon_includes_embed_fields(self) -> None:
         client = DiscordClient(webhook_url="https://discord.invalid/webhook")
-        with mock.patch.object(client.session, "post", return_value=_Resp(status_code=200, text='{"ok":true}', data={"id": "1"})) as post:
+        with mock.patch.object(
+            client.session,
+            "request",
+            return_value=_Resp(status_code=200, text='{"ok":true}', data={"id": "1"}),
+        ) as req:
             result = client.send_beacon(
                 content="hello world",
                 kind="bounty",
@@ -39,18 +47,172 @@ class TestDiscordTransport(unittest.TestCase):
                 signature_preview="abc123",
             )
             self.assertTrue(result["ok"])
-            payload = post.call_args.kwargs["json"]
+            payload = req.call_args.kwargs["json"]
             self.assertIn("embeds", payload)
             embed = payload["embeds"][0]
-            self.assertEqual(embed["title"], "Beacon Ping · BOUNTY")
+            self.assertTrue(embed["title"].endswith("BOUNTY"))
             field_names = [f["name"] for f in embed["fields"]]
             self.assertIn("RTC Tip", field_names)
             self.assertIn("Signature", field_names)
+
+    @mock.patch("beacon_skill.transports.discord.time.sleep")
+    def test_retry_429_then_success(self, sleep_mock) -> None:
+        client = DiscordClient(webhook_url="https://discord.invalid/webhook", max_attempts=3, base_delay_s=0.1)
+        rate_limited = _Resp(
+            status_code=429,
+            text='{"message":"Too Many Requests","retry_after":2}',
+            data={"message": "Too Many Requests", "retry_after": 2},
+        )
+        ok = _Resp(status_code=204, text="")
+        with mock.patch.object(client.session, "request", side_effect=[rate_limited, ok]) as req:
+            result = client.send_message("hello")
+            self.assertTrue(result["ok"])
+            self.assertEqual(req.call_count, 2)
+            sleep_mock.assert_called_once_with(2.0)
+
+    @mock.patch("beacon_skill.transports.discord.time.sleep")
+    def test_retry_5xx_then_success(self, sleep_mock) -> None:
+        client = DiscordClient(webhook_url="https://discord.invalid/webhook", max_attempts=3, base_delay_s=0.5)
+        e500 = _Resp(status_code=500, text='{"message":"Internal"}', data={"message": "Internal"})
+        ok = _Resp(status_code=200, text='{"id":"1"}', data={"id": "1"})
+        with mock.patch.object(client.session, "request", side_effect=[e500, ok]) as req:
+            result = client.send_message("hello")
+            self.assertTrue(result["ok"])
+            self.assertEqual(req.call_count, 2)
+            sleep_mock.assert_called_once_with(0.5)
+
+    def test_4xx_returns_parsed_error(self) -> None:
+        client = DiscordClient(webhook_url="https://discord.invalid/webhook")
+        bad = _Resp(status_code=400, text='{"message":"Invalid webhook"}', data={"message": "Invalid webhook"})
+        with mock.patch.object(client.session, "request", return_value=bad):
+            with self.assertRaises(DiscordError) as ctx:
+                client.send_message("hi")
+        err = ctx.exception
+        self.assertEqual(err.status_code, 400)
+        self.assertEqual(err.error_type, "client")
+        self.assertIn("Invalid webhook", str(err))
+
+    @mock.patch("beacon_skill.transports.discord.time.sleep")
+    def test_retry_request_exception_then_success(self, sleep_mock) -> None:
+        client = DiscordClient(webhook_url="https://discord.invalid/webhook", max_attempts=2, base_delay_s=0.25)
+        ok = _Resp(status_code=204, text="")
+        with mock.patch.object(
+            client.session,
+            "request",
+            side_effect=[requests.RequestException("timeout"), ok],
+        ) as req:
+            result = client.send_message("hello")
+            self.assertTrue(result["ok"])
+            self.assertEqual(req.call_count, 2)
+            sleep_mock.assert_called_once_with(0.25)
 
     def test_send_without_webhook_errors(self) -> None:
         client = DiscordClient(webhook_url="")
         with self.assertRaises(DiscordError):
             client.send_message("hi")
+
+    def test_listener_requires_bot_token_and_channel(self) -> None:
+        with self.assertRaises(DiscordError):
+            DiscordClient(bot_token="", channel_id="123").listen_messages()
+        with self.assertRaises(DiscordError):
+            DiscordClient(bot_token="token", channel_id="").listen_messages()
+
+    def test_listener_fetches_messages(self) -> None:
+        client = DiscordClient(bot_token="abc123", channel_id="111222")
+        resp = _Resp(
+            status_code=200,
+            text='[{"id":"m1"}]',
+            data=[
+                {
+                    "id": "m1",
+                    "content": "hello",
+                    "timestamp": "2026-01-01T00:00:00.000Z",
+                    "author": {"id": "u1", "username": "alice"},
+                }
+            ],
+        )
+        with mock.patch.object(client.session, "request", return_value=resp) as req:
+            result = client.listen_messages(limit=10, after_id="m0")
+            self.assertTrue(result["ok"])
+            self.assertEqual(result["count"], 1)
+            self.assertEqual(result["messages"][0]["author_username"], "alice")
+            self.assertEqual(req.call_args.args[0], "GET")
+            self.assertIn("/channels/111222/messages", req.call_args.args[1])
+            self.assertEqual(req.call_args.kwargs["params"]["after"], "m0")
+            self.assertEqual(req.call_args.kwargs["headers"]["Authorization"], "Bot abc123")
+
+
+class TestDiscordCli(unittest.TestCase):
+    def test_ping_dry_run_has_payload_shape(self) -> None:
+        args = argparse.Namespace(
+            text="hello",
+            kind="hello",
+            rtc=1.5,
+            link=["https://example.com"],
+            webhook_url="https://discord.invalid/webhook",
+            username=None,
+            avatar_url=None,
+            dry_run=True,
+            password=None,
+        )
+        with mock.patch("beacon_skill.cli.load_config", return_value={"beacon": {"agent_name": "test"}}), mock.patch(
+            "beacon_skill.cli._load_identity", return_value=None
+        ), mock.patch("beacon_skill.cli._build_envelope", return_value="[BEACON v1]\n{}\n[/BEACON]"), mock.patch(
+            "beacon_skill.cli.decode_envelopes",
+            return_value=[{"agent_id": "bcn_abc", "sig": "sig123"}],
+        ), mock.patch(
+            "builtins.print"
+        ) as print_mock:
+            rc = cmd_discord_ping(args)
+            self.assertEqual(rc, 0)
+            out = json.loads(print_mock.call_args.args[0])
+            self.assertIn("payload", out)
+            self.assertIn("embeds", out["payload"])
+            self.assertEqual(out["payload"]["embeds"][0]["fields"][0]["name"], "Kind")
+
+    def test_send_dry_run_has_payload_shape(self) -> None:
+        args = argparse.Namespace(
+            kind="bounty",
+            text="new bounty",
+            link=[],
+            bounty_url="https://example.com/bounty/1",
+            reward_rtc=120.0,
+            rtc=2.0,
+            webhook_url="https://discord.invalid/webhook",
+            username=None,
+            avatar_url=None,
+            dry_run=True,
+            password=None,
+        )
+        with mock.patch("beacon_skill.cli.load_config", return_value={"beacon": {"agent_name": "test"}}), mock.patch(
+            "beacon_skill.cli._load_identity", return_value=None
+        ), mock.patch("beacon_skill.cli._build_envelope", return_value="[BEACON v1]\n{}\n[/BEACON]"), mock.patch(
+            "beacon_skill.cli.decode_envelopes",
+            return_value=[{"agent_id": "bcn_abc", "sig": "sig123"}],
+        ), mock.patch(
+            "builtins.print"
+        ) as print_mock:
+            rc = cmd_discord_send(args)
+            self.assertEqual(rc, 0)
+            out = json.loads(print_mock.call_args.args[0])
+            self.assertIn("payload", out)
+            self.assertIn("embeds", out["payload"])
+            self.assertEqual(out["payload"]["embeds"][0]["fields"][0]["name"], "Kind")
+
+    def test_listen_dry_run(self) -> None:
+        args = argparse.Namespace(
+            channel_id="123",
+            bot_token="",
+            limit=20,
+            after_id=None,
+            dry_run=True,
+        )
+        with mock.patch("beacon_skill.cli.load_config", return_value={}), mock.patch("builtins.print") as print_mock:
+            rc = cmd_discord_listen(args)
+            self.assertEqual(rc, 0)
+            out = json.loads(print_mock.call_args.args[0])
+            self.assertEqual(out["channel_id"], "123")
+            self.assertFalse(out["bot_token_set"])
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary\nThis PR implements the real Discord transport hardening requested in rustchain-bounties#320 and integrates with the existing eacon_skill.transports patterns.\n\n### What changed\n- Hardened webhook send path in eacon_skill/transports/discord.py:\n  - explicit 429 handling with etry_after support\n  - retry for transient 5xx and network errors\n  - parsed 4xx/5xx error messages with structured DiscordError (status_code, error_type)\n- Added optional listener/read path (discord bot token + channel) in transport:\n  - listen_messages(limit, after_id) using Discord REST API (/api/v10/channels/{id}/messages)\n- Added CLI support in eacon_skill/cli.py:\n  - new eacon discord listen command\n  - discord ping/send --dry-run now outputs exact payload shape to preview webhook body\n- Added docs:\n  - docs/DISCORD.md setup + troubleshooting\n  - README updates for listener mode and dry-run payload preview\n- Added/expanded tests in 	ests/test_discord.py:\n  - 429 retry branch\n  - webhook 4xx/5xx parsing/retry behavior\n  - network exception retry\n  - listener mode auth + fetch path\n  - dry-run payload shape checks for ping/send\n\n## Validation\n- python -m pytest tests/test_discord.py -q\n  - 12 passed\n\n## Notes\n- No mock-only submission: this is wired into actual code paths used by eacon discord ping/send and new eacon discord listen.