### PR TITLE
retry: validate invalid inputs for max_attempts/base_delay

### DIFF
--- a/beacon_skill/retry.py
+++ b/beacon_skill/retry.py
@@ -39,6 +39,11 @@ def with_retry(
         jitter: Add random jitter to prevent thundering herd.
         retryable_exceptions: Extra exception types to retry on.
     """
+    if max_attempts < 1:
+        raise ValueError("max_attempts must be >= 1")
+    if base_delay < 0:
+        raise ValueError("base_delay must be >= 0")
+
     last_error: Optional[Exception] = None
 
     for attempt in range(max_attempts):

--- a/tests/test_retry.py
+++ b/tests/test_retry.py
@@ -31,6 +31,14 @@ class TestRetry(unittest.TestCase):
         with self.assertRaises(RuntimeError):
             with_retry(always_fail, max_attempts=2, base_delay=0.01)
 
+    def test_invalid_max_attempts_raises_value_error(self) -> None:
+        with self.assertRaises(ValueError):
+            with_retry(lambda: "ok", max_attempts=0)
+
+    def test_invalid_base_delay_raises_value_error(self) -> None:
+        with self.assertRaises(ValueError):
+            with_retry(lambda: "ok", base_delay=-0.1)
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Summary
Adds explicit input validation in `with_retry` so invalid arguments fail fast and clearly:
- raise `ValueError` when `max_attempts < 1`
- raise `ValueError` when `base_delay < 0`

Also adds regression tests for both cases in `tests/test_retry.py`.

## Why
Previously `max_attempts=0` would skip the retry loop and produce a less clear failure path. This PR makes argument contracts explicit and predictable.

## Verification
Ran locally:

```bash
python3 -m unittest tests/test_retry.py -v
```

Result: 5 tests passed.

Refs Scottcjn/rustchain-bounties#255
