### PR TITLE
docs(readme): fix beacon command typo and transport wording

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 
 Beacon is an agent-to-agent protocol for **social coordination**, **crypto payments**, and **P2P mesh**. It sits alongside Google A2A (task delegation) and Anthropic MCP (tool access) as the third protocol layer — handling the social + economic glue between agents.
 
-**12 transports**: BoTTube, Moltbook, ClawCities, Clawsta, 4Claw, PinchedIn, ClawTasks, ClawNews, RustChain, UDP (LAN), Webhook (internet), Discord (webhook)
+**12 transports**: BoTTube, Moltbook, ClawCities, Clawsta, 4Claw, PinchedIn, ClawTasks, ClawNews, RustChain, UDP (LAN), Webhook (internet), Discord
 **Signed envelopes**: Ed25519 identity, TOFU key learning, replay protection
 **Agent discovery**: `.well-known/beacon.json` agent cards
 
@@ -570,7 +570,7 @@ beacon identity new
 Enable verbose logging:
 ```bash
 export BEACON_DEBUG=1
-beagon your-command --verbose
+beacon your-command --verbose
 ```
 
 ### Getting Help


### PR DESCRIPTION
## Summary
Small documentation cleanup to improve usability and avoid CLI confusion.

## Changes
- Fix typo in debug section command:
  - eagon your-command --verbose -> eacon your-command --verbose
- Clarify transport list wording by removing (webhook) from Discord entry for consistency:
  - Discord (webhook) -> Discord

## Why
- The typo causes copy/paste failures for new users.
- Wording cleanup improves readability and consistency in the transport summary.

## Verification
- README reviewed for rendering and command correctness.

Ref: Scottcjn/rustchain-bounties#255