### PR TITLE
fix: preserve Discord 429 error type after retry exhaustion

### DIFF
--- a/beacon_skill/transports/discord.py
+++ b/beacon_skill/transports/discord.py
@@ -164,6 +164,10 @@ class DiscordTransport:
                 # Don't retry 4xx client errors (except 429)
                 raise
 
+        if isinstance(last_error, DiscordRateLimitError):
+            raise last_error
+        if isinstance(last_error, (DiscordServerError, requests.RequestException)):
+            raise DiscordError(f"Failed after {self.max_retries} attempts: {last_error}") from last_error
         raise DiscordError(f"Failed after {self.max_retries} attempts: {last_error}")
 
     def send_message(


### PR DESCRIPTION
## Summary\nFixes retry error propagation in DiscordTransport._send_payload.\n\nBefore this patch, repeated 429 responses were wrapped into a generic DiscordError after max retries, which dropped rate-limit metadata (etry_after) and broke callers/tests expecting DiscordRateLimitError.\n\nAfter this patch:\n- DiscordRateLimitError is re-raised after retries are exhausted\n- server/network errors still surface as wrapped DiscordError\n\n## Runtime verification\nExecuted locally:\n\n`ash\npython -m pytest tests/test_discord_transport.py::TestDiscordTransport::test_error_parsing_429 -q\n# 1 passed\n\npython -m pytest tests/test_discord_transport.py -q\n# 12 passed\n`\n\nThis is a focused single-file fix to reduce review risk and avoid duplicate/over-scoped changes.