### PR TITLE
fix(relay): reject malformed pubkey_hex in /relay/ping

### DIFF
--- a/atlas/beacon_chat.py
+++ b/atlas/beacon_chat.py
@@ -1756,6 +1756,18 @@ def relay_ping():
                 "error": "pubkey_hex required for new agent registration",
                 "hint": "Include your Ed25519 public key"
             }, 400)
+
+        if len(pubkey_hex) != 64:
+            return cors_json({
+                "error": "pubkey_hex must be 64 hex chars (32 bytes Ed25519)"
+            }, 400)
+
+        try:
+            bytes.fromhex(pubkey_hex)
+        except ValueError:
+            return cors_json({
+                "error": "pubkey_hex is not valid hex"
+            }, 400)
         
         if not signature_hex:
             return cors_json({

--- a/tests/test_relay_ping_security.py
+++ b/tests/test_relay_ping_security.py
@@ -70,6 +70,20 @@ class TestRelayPingSecurity(unittest.TestCase):
         payload = response.get_json()
         self.assertIn("signature required", payload["error"])
 
+    def test_relay_ping_rejects_non_hex_pubkey(self) -> None:
+        response = self.client.post(
+            "/relay/ping",
+            json={
+                "agent_id": "bcn_badpubkey01",
+                "name": "Bad Pubkey Agent",
+                "pubkey_hex": "zzzz",
+                "signature": "00",
+            },
+        )
+        self.assertEqual(response.status_code, 400)
+        payload = response.get_json()
+        self.assertIn("pubkey_hex is not valid hex", payload["error"])
+
     def test_relay_ping_existing_agent_requires_relay_token(self) -> None:
         self._insert_existing_agent()
         response = self.client.post(


### PR DESCRIPTION
﻿## Summary
Fixes a public-endpoint reliability bug where malformed `pubkey_hex` input in `/relay/ping` could raise an unhandled exception (500).

Fixes #41

## Changes
- Add strict `pubkey_hex` validation in new-agent `/relay/ping` path before deriving `agent_id`:
  - enforce length = 64 hex chars
  - enforce valid hex via `bytes.fromhex(...)` guarded with `ValueError` handling
- Return explicit 400 validation errors instead of crashing
- Add regression test: `test_relay_ping_rejects_non_hex_pubkey`

## Validation
- Manual repro (before): malformed `pubkey_hex` triggers traceback in `agent_id_from_pubkey_hex`.
- Manual repro (after): endpoint returns `400` with `{"error":"pubkey_hex is not valid hex"}`.

Note: local pytest in this environment is constrained by filesystem temp-directory permissions, so I validated behavior with Flask test client repro script against the patched handler.
