### PR TITLE
Validate input types in codec decode/verify

### DIFF
--- a/beacon_skill/codec.py
+++ b/beacon_skill/codec.py
@@ -137,6 +137,9 @@ def decode_envelopes(text: str) -> List[Dict[str, Any]]:
     Each returned dict includes the parsed JSON body.
     v2 envelopes include agent_id, nonce, sig fields.
     """
+    if not isinstance(text, str):
+        raise TypeError(f"decode_envelopes expects str, got {type(text).__name__}")
+
     out: List[Dict[str, Any]] = []
     idx = 0
     while True:
@@ -179,6 +182,9 @@ def verify_envelope(
 
     known_keys: dict mapping agent_id -> public_key_hex
     """
+    if not isinstance(envelope, dict):
+        raise TypeError(f"verify_envelope expects dict, got {type(envelope).__name__}")
+
     sig_hex = envelope.get("sig")
     if not sig_hex:
         return None  # v1 or unsigned

--- a/tests/test_codec.py
+++ b/tests/test_codec.py
@@ -5,6 +5,14 @@ from beacon_skill.identity import AgentIdentity
 
 
 class TestCodec(unittest.TestCase):
+    def test_decode_envelopes_rejects_non_string(self) -> None:
+        with self.assertRaises(TypeError):
+            decode_envelopes([{"kind": "invalid"}])  # type: ignore[arg-type]
+
+    def test_verify_envelope_rejects_non_dict(self) -> None:
+        with self.assertRaises(TypeError):
+            verify_envelope("not a dict")  # type: ignore[arg-type]
+
     def test_encode_decode_roundtrip(self) -> None:
         payload = {"v": 1, "kind": "hello", "from": "a", "to": "b", "ts": 123}
         txt = f"hi\n\n{encode_envelope(payload, version=1)}\nbye"


### PR DESCRIPTION
## Summary
- add strict input type validation in decode_envelopes (must be str)
- add strict input type validation in erify_envelope (must be dict)
- add tests covering non-string and non-dict rejection cases

## Why
Issue #55 reports missing input validation paths that can trigger unexpected behavior with malformed caller input. This patch fails fast with clear TypeError messages.

## Validation
- Windows local package test collection is blocked by existing upstream cntl dependency in eacon_skill/storage.py.
- Performed direct module-level validation of codec.py to confirm type guards trigger as expected.