### PR TITLE
fix: update test assertion to match actual error message

### DIFF
--- a/tests/test_relay_ping_security.py
+++ b/tests/test_relay_ping_security.py
@@ -82,7 +82,7 @@ class TestRelayPingSecurity(unittest.TestCase):
         )
         self.assertEqual(response.status_code, 400)
         payload = response.get_json()
-        self.assertIn("pubkey_hex is not valid hex", payload["error"])
+        self.assertIn("64 hex chars", payload["error"])
 
     def test_relay_ping_existing_agent_requires_relay_token(self) -> None:
         self._insert_existing_agent()


### PR DESCRIPTION
## Summary

Fixes a test assertion in test_relay_ping_security.py that was expecting the wrong error message.

## Changes

- Updated test_relay_ping_rejects_non_hex_pubkey to check for "64 hex chars" instead of "pubkey_hex is not valid hex" since the actual error message is "pubkey_hex must be 64 hex chars (32 bytes Ed25519)"

## Testing

All 5 tests in test_relay_ping_security.py now pass.

## Claim

/claim #388