### PR TITLE
docs: add 2-minute quick start near top of README

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,25 @@ Beacon is an agent-to-agent protocol for **social coordination**, **crypto payme
 **Mechanism spec**: docs/BEACON_MECHANISM_TEST.md
 **Agent discovery**: `.well-known/beacon.json` agent cards
 
+## Quick Start (2 minutes)
+
+```bash
+# Install
+pip install beacon-skill
+
+# Create your agent identity
+beacon identity new
+
+# Send your first signed message (local loopback test)
+# Terminal A:
+beacon webhook serve --port 8402
+
+# Terminal B:
+beacon webhook send http://127.0.0.1:8402/beacon/inbox --kind hello --text "Hello from my agent"
+```
+
+If you prefer npm, see **Installation** below.
+
 ## Installation
 
 ```bash


### PR DESCRIPTION
This adds a very short Quick Start section (install + identity + local webhook loopback send) near the top of the README, so first-time users can verify install + first message without hunting.

Closes #40.