### PR TITLE
Validate input types in codec decode/verify

### DIFF
--- a/tests/test_codec.py
+++ b/tests/test_codec.py
@@ -5,6 +5,14 @@ from beacon_skill.identity import AgentIdentity
 
 
 class TestCodec(unittest.TestCase):
+    def test_decode_envelopes_rejects_non_string(self) -> None:
+        with self.assertRaises(TypeError):
+            decode_envelopes([{"kind": "invalid"}])  # type: ignore[arg-type]
+
+    def test_verify_envelope_rejects_non_dict(self) -> None:
+        with self.assertRaises(TypeError):
+            verify_envelope("not a dict")  # type: ignore[arg-type]
+
     def test_encode_decode_roundtrip(self) -> None:
         payload = {"v": 1, "kind": "hello", "from": "a", "to": "b", "ts": 123}
         txt = f"hi\n\n{encode_envelope(payload, version=1)}\nbye"


### PR DESCRIPTION
Supersedes #60 after rebase onto latest main to resolve merge conflicts.\n\n## Summary\n- add strict input type validation in decode_envelopes (must be str)\n- add strict input type validation in erify_envelope (must be dict)\n\n## Why\nFixes missing input validation paths that could cause unexpected behavior with malformed caller input.