### PR TITLE
Fix duplicate Quick Start section in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,7 +81,7 @@ beacon webhook send http://127.0.0.1:8402/beacon/inbox --kind hello
 beacon inbox list --limit 1
 ```
 
-## Quick Start
+## Quick Start (UDP)
 
 ```bash
 # Create your agent identity (Ed25519 keypair)


### PR DESCRIPTION
## Summary
Fixed duplicate "Quick Start" section in README.md by renaming the second occurrence to "Quick Start (UDP)" to distinguish it from the webhook example.

## Changes
- Renamed second "Quick Start" heading to "Quick Start (UDP)"
- Improves clarity for new users
- Both sections remain valuable as they demonstrate different transport methods

## Testing
- Verified the change renders correctly in markdown
- No functional changes, documentation only

## Bounty Claim
This PR is submitted for bounty #255 (README improvement - 5 RTC)
- **RTC Wallet:** `RTCd02ce3312ce333e1d313201f552ac2d035355429`
- **Type:** Documentation improvement
