### PR TITLE
feat: Add --json output mode to status command

### DIFF
--- a/beacon_skill/cli.py
+++ b/beacon_skill/cli.py
@@ -199,6 +199,49 @@ def _ask_multi(prompt: str, options: List[str], defaults: Optional[List[str]] = 
     return selected if selected else (defaults or [])
 
 
+def cmd_status(args: argparse.Namespace) -> int:
+    """Show beacon status (version, config path, identity status)."""
+    import os
+    from .config import load_config
+    from .identity import AgentIdentity
+    
+    config_path = os.path.join(os.path.expanduser("~"), ".beacon", "config.json")
+    has_config = os.path.exists(config_path)
+    has_identity = False
+    agent_id = None
+    pubkey = None
+    
+    try:
+        ident = AgentIdentity.load(password=getattr(args, "password", None))
+        has_identity = True
+        agent_id = ident.agent_id
+        pubkey = ident.public_key_hex
+    except Exception:
+        pass
+    
+    result = {
+        "version": __version__,
+        "config_path": config_path,
+        "has_config": has_config,
+        "has_identity": has_identity,
+        "agent_id": agent_id,
+        "public_key": pubkey,
+    }
+    
+    if getattr(args, "json", False):
+        print(json.dumps(result, indent=2))
+    else:
+        print(f"Beacon Status")
+        print(f"  Version:      {result['version']}")
+        print(f"  Config:       {result['config_path']}")
+        print(f"  Has Config:   {result['has_config']}")
+        print(f"  Has Identity: {result['has_identity']}")
+        if agent_id:
+            print(f"  Agent ID:     {agent_id}")
+            print(f"  Public Key:   {pubkey}")
+    return 0
+
+
 def cmd_init(args: argparse.Namespace) -> int:
     # Non-interactive mode: just write defaults
     if getattr(args, "quick", False) or not sys.stdin.isatty():
@@ -4517,6 +4560,12 @@ def main(argv: Optional[List[str]] = None) -> None:
     p = argparse.ArgumentParser(prog="beacon", description="Beacon 2.4.0 - autonomous agent economy: presence, trust, feed, rules, tasks, memory, outbox, executor, mayday, heartbeat, accord")
     p.add_argument("--version", action="version", version=__version__)
     sub = p.add_subparsers(dest="cmd", required=True)
+
+    # status
+    sp = sub.add_parser("status", help="Show beacon status (version, config, identity)")
+    sp.add_argument("--json", action="store_true", help="Output as JSON")
+    sp.add_argument("--password", default=None, help="Password for encrypted identity")
+    sp.set_defaults(func=cmd_status)
 
     # init
     sp = sub.add_parser("init", help="Create ~/.beacon/config.json (interactive questionnaire)")


### PR DESCRIPTION
## Summary
This PR adds a new `beacon status` command with `--json` output mode for scripting and automation.

## Changes
- ✅ New `beacon status` command shows version, config path, and identity status
- ✅ `--json` flag outputs results as valid JSON
- ✅ Without `--json`, outputs human-readable text (backward compatible)
- ✅ All existing data fields included
- ✅ Fixes issue #73

## Usage
```bash
# Human-readable output (default)
beacon status

# JSON output for scripting
beacon status --json
```

## Bounty Claim
This PR addresses issue #73: [Bounty] Add --json output mode - 2 RTC

Ready for review! 📟