### PR TITLE
feat: Add --json output mode for CLI

### DIFF
--- a/beacon_skill/cli.py
+++ b/beacon_skill/cli.py
@@ -4514,8 +4514,20 @@ def cmd_dashboard(args: argparse.Namespace) -> int:
 # ── Argument parser ──
 
 def main(argv: Optional[List[str]] = None) -> None:
+    argv_list = list(argv) if argv is not None else sys.argv[1:]
+    json_mode = "--json" in argv_list
+    if json_mode:
+        argv_list = [arg for arg in argv_list if arg != "--json"]
+    if "--version" in argv_list:
+        if json_mode:
+            print(json.dumps({"version": __version__}))
+        else:
+            print(__version__)
+        raise SystemExit(0)
+
     p = argparse.ArgumentParser(prog="beacon", description="Beacon 2.4.0 - autonomous agent economy: presence, trust, feed, rules, tasks, memory, outbox, executor, mayday, heartbeat, accord")
-    p.add_argument("--version", action="version", version=__version__)
+    p.add_argument("--version", action="store_true", help="Show Beacon version and exit")
+    p.add_argument("--json", action="store_true", help="Output command results as JSON")
     sub = p.add_subparsers(dest="cmd", required=True)
 
     # init
@@ -5797,7 +5809,8 @@ def main(argv: Optional[List[str]] = None) -> None:
 
     register_agentmatrix_parser(sub)
 
-    args = p.parse_args(argv)
+    args = p.parse_args(argv_list)
+    args.json = json_mode or bool(getattr(args, "json", False))
     rc = args.func(args)
     raise SystemExit(rc)
 

--- a/tests/test_cli_json_flag.py
+++ b/tests/test_cli_json_flag.py
@@ -1,0 +1,49 @@
+import json
+import sys
+import unittest
+from io import StringIO
+from unittest import mock
+
+from beacon_skill import __version__
+from beacon_skill.cli import main
+
+
+class TestCliJsonFlag(unittest.TestCase):
+    def setUp(self) -> None:
+        self._stdout = sys.stdout
+        self._stderr = sys.stderr
+
+    def tearDown(self) -> None:
+        sys.stdout = self._stdout
+        sys.stderr = self._stderr
+
+    def _run(self, argv):
+        sys.stdout = StringIO()
+        sys.stderr = StringIO()
+        try:
+            main(argv)
+            code = 0
+        except SystemExit as e:
+            code = e.code
+        return code, sys.stdout.getvalue(), sys.stderr.getvalue()
+
+    def test_version_json_output(self):
+        code, stdout, _ = self._run(["--version", "--json"])
+        self.assertEqual(code, 0)
+        self.assertEqual(json.loads(stdout), {"version": __version__})
+
+    @mock.patch("beacon_skill.identity.AgentIdentity.load")
+    def test_identity_show_accepts_json_flag(self, mock_load):
+        mock_load.return_value = mock.Mock(to_dict=mock.Mock(return_value={
+            "agent_id": "bcn_test123456789",
+            "public_key_hex": "ab" * 32,
+        }))
+        code, stdout, _ = self._run(["identity", "show", "--json"])
+        self.assertEqual(code, 0)
+        parsed = json.loads(stdout)
+        self.assertEqual(parsed["agent_id"], "bcn_test123456789")
+        self.assertEqual(parsed["public_key_hex"], "ab" * 32)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

This PR adds JSON output support to the Beacon CLI.

## Changes

- ✅ Added `--json` flag for JSON output
- ✅ `beacon --version --json` returns `{"version":"2.15.1"}`
- ✅ `beacon identity show --json` returns JSON object
- ✅ Existing text output unchanged without flag
- ✅ Added unit tests for JSON output

## Testing

```bash
# JSON version
beacon --version --json
# Output: {"version": "2.15.1"}

# JSON identity
beacon identity show --json
# Output: {"agent_id": "...", "public_key_hex": "..."}

# Text output unchanged
beacon --version
# Output: 2.15.1
```

## Unit Tests

```bash
python3 -m unittest tests.test_cli_json_flag
# 2 tests passed
```

Closes #73

**My RTC Wallet**: `4nENT1fKHrasr9VWUVmi23x2uqrRuVNBpjZLURGH1GQg`

🤖 Generated by Claw (AI Agent) with Codex CLI (GPT-5.3)