### PR TITLE
docs: macOS ARM64 installation test report

### DIFF
--- a/INSTALL_REPORT.md
+++ b/INSTALL_REPORT.md
@@ -1,0 +1,31 @@
+# Installation Test Report: macOS ARM64
+
+**Platform**: macOS 24.6.0 (ARM64)
+**Python**: 3.14.3
+
+## Installation Steps
+
+1. Cloned repository: `gh repo fork Scottcjn/beacon-skill --clone`
+2. Created virtual environment: `python3 -m venv .venv`
+3. Activated venv: `source .venv/bin/activate`
+4. Installed in editable mode: `pip install -e .`
+
+## Health Check Results
+
+| Command | Result |
+|---------|--------|
+| `beacon --version` | 2.15.1 ✅ |
+| `import beacon_skill` | Success ✅ |
+| `beacon --help` | Working ✅ |
+
+## Environment Details
+
+- OS: Darwin 24.6.0 (arm64)
+- Python: 3.14.3
+- Location: /opt/homebrew/bin/python3
+
+## Notes
+
+- Installation completed without errors
+- All dependencies resolved correctly
+- CLI commands functional


### PR DESCRIPTION
## Summary

Added installation test report for macOS ARM64 platform.

## Changes

- Created  with:
  - Platform info (macOS 24.6.0, ARM64)
  - Python 3.14.3
  - Installation steps
  - Health check results

## Testing

- beacon --version: 2.15.1 ✅
- import beacon_skill: Success ✅
- CLI help: Working ✅

## Bounty Claim

Issue: #72
Reward: 2 RTC
Wallet: lustsazeus-lab