### PR TITLE
feat: add per-endpoint API rate limiting

### DIFF
--- a/beacon_skill/rate_limiter.py
+++ b/beacon_skill/rate_limiter.py
@@ -1,0 +1,156 @@
+# SPDX-License-Identifier: MIT
+"""Per-endpoint API rate limiting for the Beacon webhook server.
+
+Provides a simple in-memory token-bucket rate limiter with configurable
+per-endpoint limits. Designed for the stdlib HTTPServer — no Flask required.
+
+Usage:
+    limiter = RateLimiter(default_rpm=60)
+    limiter.set_limit("/api/miners", rpm=30)
+
+    # In request handler:
+    if not limiter.allow(path, client_ip):
+        send_429_response()
+"""
+
+from __future__ import annotations
+
+import time
+import threading
+from dataclasses import dataclass, field
+from typing import Dict, Optional, Tuple
+
+
+@dataclass
+class _Bucket:
+    """Token bucket for a single (endpoint, client) pair."""
+    tokens: float
+    max_tokens: float
+    refill_rate: float  # tokens per second
+    last_refill: float = field(default_factory=time.monotonic)
+
+    def consume(self) -> bool:
+        """Try to consume one token. Returns True if allowed."""
+        now = time.monotonic()
+        elapsed = now - self.last_refill
+        self.tokens = min(self.max_tokens, self.tokens + elapsed * self.refill_rate)
+        self.last_refill = now
+
+        if self.tokens >= 1.0:
+            self.tokens -= 1.0
+            return True
+        return False
+
+    @property
+    def retry_after_s(self) -> float:
+        """Seconds until the next token is available."""
+        if self.tokens >= 1.0:
+            return 0.0
+        return max(0.0, (1.0 - self.tokens) / self.refill_rate)
+
+
+class RateLimiter:
+    """In-memory per-endpoint, per-client rate limiter.
+
+    Args:
+        default_rpm: Default requests per minute for any /api/* endpoint.
+        burst: Burst allowance (extra tokens above steady-state).
+        cleanup_interval_s: How often to prune expired buckets.
+    """
+
+    def __init__(
+        self,
+        default_rpm: int = 60,
+        burst: int = 10,
+        cleanup_interval_s: float = 300.0,
+    ):
+        self.default_rpm = default_rpm
+        self.burst = burst
+        self.cleanup_interval_s = cleanup_interval_s
+
+        self._endpoint_limits: Dict[str, int] = {}  # path -> rpm
+        self._buckets: Dict[Tuple[str, str], _Bucket] = {}  # (path, ip) -> bucket
+        self._lock = threading.Lock()
+        self._last_cleanup = time.monotonic()
+
+    def set_limit(self, path: str, rpm: int) -> None:
+        """Set a custom rate limit for a specific endpoint.
+
+        Args:
+            path: The endpoint path (e.g., "/api/miners").
+            rpm: Requests per minute allowed per client IP.
+        """
+        self._endpoint_limits[path] = rpm
+
+    def get_limit(self, path: str) -> int:
+        """Get the effective RPM limit for a path."""
+        # Exact match first
+        if path in self._endpoint_limits:
+            return self._endpoint_limits[path]
+        # Prefix match for nested paths
+        for prefix, rpm in self._endpoint_limits.items():
+            if path.startswith(prefix):
+                return rpm
+        return self.default_rpm
+
+    def allow(self, path: str, client_ip: str) -> Tuple[bool, float]:
+        """Check if a request is allowed.
+
+        Args:
+            path: Request path.
+            client_ip: Client IP address.
+
+        Returns:
+            (allowed, retry_after_seconds) tuple.
+        """
+        # Only rate-limit /api/* endpoints
+        if not path.startswith("/api/"):
+            return True, 0.0
+
+        rpm = self.get_limit(path)
+        refill_rate = rpm / 60.0  # tokens per second
+        max_tokens = float(rpm + self.burst)
+        key = (path, client_ip)
+
+        with self._lock:
+            self._maybe_cleanup()
+
+            bucket = self._buckets.get(key)
+            if bucket is None:
+                bucket = _Bucket(
+                    tokens=max_tokens,
+                    max_tokens=max_tokens,
+                    refill_rate=refill_rate,
+                )
+                self._buckets[key] = bucket
+
+            allowed = bucket.consume()
+            retry_after = 0.0 if allowed else bucket.retry_after_s
+            return allowed, retry_after
+
+    def _maybe_cleanup(self) -> None:
+        """Remove stale buckets to prevent memory leaks."""
+        now = time.monotonic()
+        if now - self._last_cleanup < self.cleanup_interval_s:
+            return
+
+        self._last_cleanup = now
+        stale_keys = []
+        for key, bucket in self._buckets.items():
+            # If bucket is full (no activity), it's stale
+            if now - bucket.last_refill > self.cleanup_interval_s:
+                stale_keys.append(key)
+
+        for key in stale_keys:
+            del self._buckets[key]
+
+    def reset(self) -> None:
+        """Clear all buckets (for testing)."""
+        with self._lock:
+            self._buckets.clear()
+
+    @property
+    def active_buckets(self) -> int:
+        """Number of active rate limit buckets."""
+        with self._lock:
+            return len(self._buckets)

--- a/beacon_skill/transports/webhook.py
+++ b/beacon_skill/transports/webhook.py
@@ -12,6 +12,7 @@ from ..codec import decode_envelopes, verify_envelope
 from ..guard import check_envelope_window
 from ..identity import AgentIdentity
 from ..inbox import _learn_key_from_envelope, load_known_keys, save_known_keys
+from ..rate_limiter import RateLimiter
 from ..storage import append_jsonl
 
 
@@ -30,7 +31,25 @@ class WebhookHandler(BaseHTTPRequestHandler):
         self.end_headers()
         self.wfile.write(body)
 
+    def _check_rate_limit(self) -> bool:
+        """Check rate limit for /api/* endpoints. Returns True if blocked."""
+        limiter = getattr(self.server, "beacon_rate_limiter", None)
+        if limiter is None:
+            return False
+        client_ip = self.client_address[0]
+        allowed, retry_after = limiter.allow(self.path, client_ip)
+        if not allowed:
+            self._send_json(429, {
+                "error": "Rate limit exceeded",
+                "retry_after_seconds": round(retry_after, 1),
+            })
+            return True
+        return False
+
     def do_GET(self) -> None:
+        if self._check_rate_limit():
+            return
+
         if self.path == "/beacon/health":
             identity = self.server.beacon_identity
             data = {"ok": True, "beacon_version": "1.0.0"}
@@ -50,6 +69,9 @@ class WebhookHandler(BaseHTTPRequestHandler):
         self._send_json(404, {"error": "Not found"})
 
     def do_POST(self) -> None:
+        if self._check_rate_limit():
+            return
+
         if self.path != "/beacon/inbox":
             self._send_json(404, {"error": "Not found"})
             return
@@ -149,11 +171,13 @@ class WebhookServer:
         host: str = "0.0.0.0",
         identity: Optional[AgentIdentity] = None,
         agent_card: Optional[Dict[str, Any]] = None,
+        rate_limiter: Optional[RateLimiter] = None,
     ):
         self.port = port
         self.host = host
         self.identity = identity
         self.agent_card = agent_card
+        self.rate_limiter = rate_limiter
         self._server: Optional[HTTPServer] = None
         self._thread: Optional[threading.Thread] = None
 
@@ -162,6 +186,7 @@ class WebhookServer:
         self._server = HTTPServer((self.host, self.port), WebhookHandler)
         self._server.beacon_identity = self.identity
         self._server.beacon_agent_card = self.agent_card
+        self._server.beacon_rate_limiter = self.rate_limiter
 
         if blocking:
             self._server.serve_forever()

--- a/tests/test_rate_limiter.py
+++ b/tests/test_rate_limiter.py
@@ -1,0 +1,139 @@
+# SPDX-License-Identifier: MIT
+"""Tests for the per-endpoint API rate limiter."""
+
+import time
+import unittest
+from unittest.mock import patch
+
+from beacon_skill.rate_limiter import RateLimiter, _Bucket
+
+
+class TestBucket(unittest.TestCase):
+    """Token bucket internals."""
+
+    def test_consume_when_tokens_available(self):
+        b = _Bucket(tokens=5.0, max_tokens=10.0, refill_rate=1.0)
+        self.assertTrue(b.consume())
+        self.assertAlmostEqual(b.tokens, 4.0, delta=0.1)
+
+    def test_consume_when_empty(self):
+        b = _Bucket(tokens=0.0, max_tokens=10.0, refill_rate=1.0)
+        b.last_refill = time.monotonic()
+        self.assertFalse(b.consume())
+
+    def test_refill_over_time(self):
+        b = _Bucket(tokens=0.0, max_tokens=10.0, refill_rate=100.0)
+        b.last_refill = time.monotonic() - 1.0  # 1 second ago
+        self.assertTrue(b.consume())  # Should have refilled
+
+    def test_tokens_capped_at_max(self):
+        b = _Bucket(tokens=10.0, max_tokens=10.0, refill_rate=100.0)
+        b.last_refill = time.monotonic() - 10.0
+        b.consume()
+        self.assertLessEqual(b.tokens, b.max_tokens)
+
+    def test_retry_after_when_empty(self):
+        b = _Bucket(tokens=0.0, max_tokens=10.0, refill_rate=1.0)
+        b.last_refill = time.monotonic()
+        self.assertGreater(b.retry_after_s, 0)
+
+    def test_retry_after_when_available(self):
+        b = _Bucket(tokens=5.0, max_tokens=10.0, refill_rate=1.0)
+        self.assertEqual(b.retry_after_s, 0.0)
+
+
+class TestRateLimiter(unittest.TestCase):
+    """Rate limiter public API."""
+
+    def test_non_api_paths_always_allowed(self):
+        limiter = RateLimiter(default_rpm=1)
+        allowed, _ = limiter.allow("/beacon/health", "1.2.3.4")
+        self.assertTrue(allowed)
+
+    def test_api_path_allowed_within_limit(self):
+        limiter = RateLimiter(default_rpm=60, burst=10)
+        allowed, _ = limiter.allow("/api/miners", "1.2.3.4")
+        self.assertTrue(allowed)
+
+    def test_api_path_blocked_after_burst(self):
+        limiter = RateLimiter(default_rpm=1, burst=0)
+        # First request: uses the initial token (rpm + burst = 1)
+        allowed1, _ = limiter.allow("/api/miners", "1.2.3.4")
+        self.assertTrue(allowed1)
+        # Second request: should be blocked
+        allowed2, retry = limiter.allow("/api/miners", "1.2.3.4")
+        self.assertFalse(allowed2)
+        self.assertGreater(retry, 0)
+
+    def test_different_clients_independent(self):
+        limiter = RateLimiter(default_rpm=1, burst=0)
+        limiter.allow("/api/miners", "1.1.1.1")
+        # Different IP should still be allowed
+        allowed, _ = limiter.allow("/api/miners", "2.2.2.2")
+        self.assertTrue(allowed)
+
+    def test_different_endpoints_independent(self):
+        limiter = RateLimiter(default_rpm=1, burst=0)
+        limiter.allow("/api/miners", "1.1.1.1")
+        # Different endpoint should still be allowed
+        allowed, _ = limiter.allow("/api/nodes", "1.1.1.1")
+        self.assertTrue(allowed)
+
+    def test_custom_endpoint_limit(self):
+        limiter = RateLimiter(default_rpm=100, burst=0)
+        limiter.set_limit("/api/miners", rpm=1)
+        limiter.allow("/api/miners", "1.1.1.1")
+        allowed, _ = limiter.allow("/api/miners", "1.1.1.1")
+        self.assertFalse(allowed)
+        # Other endpoints still use default
+        allowed2, _ = limiter.allow("/api/nodes", "1.1.1.1")
+        self.assertTrue(allowed2)
+
+    def test_get_limit_default(self):
+        limiter = RateLimiter(default_rpm=60)
+        self.assertEqual(limiter.get_limit("/api/unknown"), 60)
+
+    def test_get_limit_custom(self):
+        limiter = RateLimiter(default_rpm=60)
+        limiter.set_limit("/api/miners", rpm=30)
+        self.assertEqual(limiter.get_limit("/api/miners"), 30)
+
+    def test_reset_clears_buckets(self):
+        limiter = RateLimiter(default_rpm=60)
+        limiter.allow("/api/test", "1.1.1.1")
+        self.assertGreater(limiter.active_buckets, 0)
+        limiter.reset()
+        self.assertEqual(limiter.active_buckets, 0)
+
+    def test_cleanup_removes_stale_buckets(self):
+        limiter = RateLimiter(default_rpm=60, cleanup_interval_s=0)
+        limiter.allow("/api/test", "1.1.1.1")
+        # Manually age the bucket
+        with limiter._lock:
+            for bucket in limiter._buckets.values():
+                bucket.last_refill = time.monotonic() - 999
+            limiter._last_cleanup = 0
+        # Next call triggers cleanup
+        limiter.allow("/api/other", "2.2.2.2")
+        # Stale bucket should be cleaned
+        self.assertEqual(limiter.active_buckets, 1)
+
+    def test_prefix_match_for_nested_paths(self):
+        limiter = RateLimiter(default_rpm=100)
+        limiter.set_limit("/api/miners", rpm=5)
+        self.assertEqual(limiter.get_limit("/api/miners/active"), 5)
+
+
+class TestWebhookIntegration(unittest.TestCase):
+    """Test rate limiter integration with webhook handler."""
+
+    def test_rate_limiter_parameter_accepted(self):
+        """WebhookServer should accept rate_limiter parameter."""
+        from beacon_skill.transports.webhook import WebhookServer
+        limiter = RateLimiter(default_rpm=30)
+        server = WebhookServer(port=0, rate_limiter=limiter)
+        self.assertIs(server.rate_limiter, limiter)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Refs Scottcjn/rustchain-bounties#557

## Changes
Standalone `rate_limiter.py` module + integration into `WebhookHandler`.

### Rate Limiter
- Token-bucket algorithm, per-endpoint, per-client IP
- Configurable per-endpoint limits via `set_limit("/api/miners", rpm=30)`
- Burst allowance for traffic spikes
- Auto-cleanup of stale buckets (no memory leaks)
- Thread-safe (stdlib only, no Flask dependency)
- Non-API paths (`/beacon/*`) are never rate-limited

### Integration
- `WebhookHandler._check_rate_limit()` called before GET and POST
- Returns 429 with `retry_after_seconds` when limit exceeded
- `WebhookServer` accepts optional `rate_limiter` parameter

### Tests
18 tests in `tests/test_rate_limiter.py`:
- 6 bucket internals (consume, refill, cap, retry_after)
- 11 limiter behavior (allow, block, per-client, per-endpoint, cleanup, prefix match)
- 1 webhook integration

```
18 passed in 0.98s
```

Clean separation from docs — this is code-only.

**BCOS-L2** (touches API security)

**Wallet:** will provide on acceptance