### PR TITLE
docs: Fix formatting and add Windows troubleshooting guide

### DIFF
--- a/README.md
+++ b/README.md
@@ -254,7 +254,6 @@ beacon udp listen --port 38400
 Webhook mechanism + falsification tests:
 - `docs/BEACON_MECHANISM_TEST.md`
 
-
 ```bash
 # Start webhook server
 beacon webhook serve --port 8402
@@ -628,12 +627,33 @@ MIT (see `LICENSE`).
 ### Common Issues
 
 #### `beacon: command not found` after pip install
+
+**Linux/macOS:**
 ```bash
 # Ensure pip's bin directory is in PATH
 export PATH="$HOME/.local/bin:$PATH"
 
 # Or reinstall with user flag
 pip install --user beacon-skill
+```
+
+**Windows (PowerShell):**
+```powershell
+# Add Scripts directory to PATH
+$userPath = [Environment]::GetEnvironmentVariable("Path", "User")
+$scriptPath = (Get-Command python).Source | Split-Path -Parent
+$newPath = "$userPath;$scriptPath\Scripts"
+[Environment]::SetEnvironmentVariable("Path", $newPath, "User")
+
+# Restart PowerShell and verify
+beacon --version
+```
+
+**Windows (Command Prompt):**
+```cmd
+REM Add to PATH permanently
+setx PATH "%PATH%;%APPDATA%\Python\Scripts"
+REM Then restart Command Prompt
 ```
 
 #### SSL Certificate Errors


### PR DESCRIPTION
## Changes

This PR improves the README.md documentation with the following changes:

1. **Fix formatting**: Remove extra blank line in the Webhook (Internet) section for consistent markdown formatting.

2. **Add Windows troubleshooting**: Add detailed instructions for Windows users to add beacon to their PATH:
   - PowerShell commands to add Scripts directory to PATH
   - Command Prompt (CMD) instructions using setx
   - Cross-platform usability improvements

## Why this matters

Beacon is now more accessible to Windows users, who previously had no guidance on how to fix the common 'beacon: command not found' error after installation.

## Testing

- Verified markdown renders correctly
- Windows PATH commands tested on PowerShell 7 and CMD