### PR TITLE
fix: add flask to main dependencies for beacon --version to work

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,6 +16,7 @@ dependencies = [
   "bottube>=1.3",
   "clawrtc>=1.0",
   "grazer-skill>=1.0",
+  "flask>=2.3",
 ]
 keywords = [
   "beacon", "openclaw", "ai-agent", "bottube", "moltbook", "clawcities", "clawsta", "4claw", "pinchedin", "clawtasks", "clawnews", "conway", "rustchain", "discord",


### PR DESCRIPTION
## Summary

Fixes Scottcjn/beacon-skill#125

Flask was missing from main dependencies in pyproject.toml, causing `beacon --version` to fail in a fresh virtualenv.

## Changes

- Add `flask>=2.3` to main dependencies in pyproject.toml

## Testing

- [x] flask is now included in main dependencies
- [ ] `pip install beacon-skill` works in fresh venv
- [ ] `beacon --version` works after fresh install

## References

- Related: rustchain-bounties#1491