### PR TITLE
fix: install cleanup - missing Flask dep and CLI alignment

### DIFF
--- a/beacon_skill/cli.py
+++ b/beacon_skill/cli.py
@@ -1438,14 +1438,33 @@ def cmd_webhook_serve(args: argparse.Namespace) -> int:
 
 def cmd_webhook_send(args: argparse.Namespace) -> int:
     from .transports.webhook import webhook_send
+    cfg = load_config()
     identity = _load_identity(args)
+
+    links = args.link or []
+    extra: Dict[str, Any] = {}
+    if args.bounty_url:
+        extra["bounty_url"] = args.bounty_url
+    if args.reward_rtc is not None:
+        extra["reward_rtc"] = float(args.reward_rtc)
+    if args.text:
+        extra["text"] = args.text
+
+    try:
+        extra.update(_parse_kv_fields(args.field or []))
+    except ValueError as e:
+        print(str(e), file=sys.stderr)
+        return 2
 
     payload: Dict[str, Any] = {
         "kind": args.kind,
-        "from": "",
+        "from": _cfg_get(cfg, "beacon", "agent_name", default=""),
         "to": args.url,
         "ts": int(time.time()),
     }
+    if links:
+        payload["links"] = links
+    payload.update(extra)
 
     if identity:
         text = encode_envelope(payload, version=2, identity=identity, include_pubkey=True)
@@ -4900,6 +4919,11 @@ def main(argv: Optional[List[str]] = None) -> None:
     sp = wh_sub.add_parser("send", help="Send a beacon to a webhook endpoint")
     sp.add_argument("url", help="Webhook URL (e.g. http://host:8402/beacon/inbox)")
     sp.add_argument("--kind", default="hello", help="Envelope kind (default: hello)")
+    sp.add_argument("--text", default="", help="Message text")
+    sp.add_argument("--link", action="append", default=[], help="Attach a link (repeatable)")
+    sp.add_argument("--bounty-url", default=None, help="Attach a bounty URL")
+    sp.add_argument("--reward-rtc", type=float, default=None, help="Attach a bounty reward (RTC)")
+    sp.add_argument("--field", action="append", default=[], help="Attach extra fields (k=v)")
     sp.add_argument("--password", default=None, help="Password for encrypted identity")
     sp.set_defaults(func=cmd_webhook_send)
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,6 +16,7 @@ dependencies = [
   "bottube>=1.3",
   "clawrtc>=1.0",
   "grazer-skill>=1.0",
+  "flask>=2.3",
 ]
 keywords = [
   "beacon", "openclaw", "ai-agent", "bottube", "moltbook", "clawcities", "clawsta", "4claw", "pinchedin", "clawtasks", "clawnews", "conway", "rustchain", "discord",

--- a/tests/smoke_test.py
+++ b/tests/smoke_test.py
@@ -1,0 +1,27 @@
+import subprocess
+import os
+import sys
+
+def test_install_and_version():
+    print("Testing beacon --version...")
+    try:
+        # We test against the local source
+        env = os.environ.copy()
+        env["PYTHONPATH"] = "."
+        result = subprocess.run(["python3", "-m", "beacon_skill.cli", "--version"], 
+                               capture_output=True, text=True, env=env)
+        if result.returncode == 0:
+            print(f"SUCCESS: {result.stdout.strip()}")
+            return True
+        else:
+            print(f"FAILED: {result.stderr}")
+            return False
+    except Exception as e:
+        print(f"ERROR: {e}")
+        return False
+
+if __name__ == "__main__":
+    if test_install_and_version():
+        sys.exit(0)
+    else:
+        sys.exit(1)


### PR DESCRIPTION
This PR addresses Issue #125 / Bounty #1491.

### Changes:
- Moved `flask` from optional `conway` dependencies to core `dependencies` in `pyproject.toml` to ensure `beacon webhook serve` works out-of-the-box.
- Updated `beacon webhook send` CLI to support `--text`, `--link`, `--bounty-url`, and other flags, aligning it with the examples in README.md and other transports like UDP.
- Added `tests/smoke_test.py` to verify basic CLI functionality.

Verified in a fresh environment.

Wallet: whitebrendan (miner_id)