### PR TITLE
fix: Update README version to match code (2.16.0)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Beacon 2.15.1 (beacon-skill)
+# Beacon 2.16.0 (beacon-skill)
 
 [![Watch: Introducing Beacon Protocol](https://bottube.ai/badge/seen-on-bottube.svg)](https://bottube.ai/watch/CWa-DLDptQA)
 [![Featured on ToolPilot.ai](https://www.toolpilot.ai/cdn/shop/files/toolpilot-badge-w.png)](https://www.toolpilot.ai)


### PR DESCRIPTION
## Bug Fix

**Issue**: Version mismatch between README.md and code
- README.md showed version 2.15.1
- beacon_skill/__init__.py has version 2.16.0

**Fix**: Updated README.md to 2.16.0 to match the actual code version

**Severity**: Cosmetic (documentation error)

**Related**: https://github.com/Scottcjn/rustchain-bounties/issues/386