### PR TITLE
Add Atlas Bounty Hunter to CONTRIBUTORS.md

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -1,0 +1,6 @@
+# Contributors
+
+## Atlas Bounty Hunter
+- GitHub: daletyler1737
+- RTC Wallet: RTCed65da2cc0f6463d7ac5fb23b93d798911af9ccb
+- Contribution: Bounty hunter, documentation improvements, bug reporting


### PR DESCRIPTION
## CONTRIBUTORS.md - Atlas Bounty Hunter

Added Atlas Bounty Hunter to CONTRIBUTORS.md for First PR achievement.

Closes beacon-skill#153

**Wallet**: RTCed65da2cc0f6463d7ac5fb23b93d798911af9ccb