### PR TITLE
fix(ci): rename first-interaction inputs to underscore form

### DIFF
--- a/.github/workflows/welcome.yml
+++ b/.github/workflows/welcome.yml
@@ -16,8 +16,8 @@ jobs:
     steps:
       - uses: actions/first-interaction@v3.1.0
         with:
-          repo-token: ${{ secrets.GITHUB_TOKEN }}
-          issue-message: |
+          repo_token: ${{ secrets.GITHUB_TOKEN }}
+          issue_message: |
             Welcome to beacon-skill! Thanks for opening your first issue.
 
             **New here?** Check out:
@@ -26,7 +26,7 @@ jobs:
             - [Beacon Atlas](https://rustchain.org/beacon/) — live agent network
 
             Every merged PR earns RTC bounties! 1 RTC = $0.10 USD
-          pr-message: |
+          pr_message: |
             Welcome to beacon-skill! Thanks for your first pull request.
 
             **Quick checklist:**


### PR DESCRIPTION
Fixes every recent Welcome New Contributors run: [example failed run](https://github.com/Scottcjn/beacon-skill/actions/runs/24768390459).

### Root cause

`actions/first-interaction` renamed its inputs between v1 and v3:

| v1.x (hyphenated) | v3.x (underscored) |
|---|---|
| `repo-token` | `repo_token` |
| `issue-message` | `issue_message` |
| `pr-message` | `pr_message` |

`welcome.yml` uses `@v3.1.0` but still passes the v1 names, so the runtime logs:

```
Warning: Unexpected input(s) 'repo-token', 'issue-message', 'pr-message',
         valid inputs are ['issue_message', 'pr_message', 'repo_token']
Error: Input required and not supplied: issue_message
```

### Fix

Three-character rename. No action version change, no permissions change, no content change. After merge, new-contributor auto-welcome messages start posting again on issues and PRs.

### Scope

Checked Scott's other repos — only `beacon-skill/welcome.yml` has this specific pattern. Other hyphenated `issue-message` occurrences are in `stale.yml` and `close-issue.yml` workflows, which use different actions (`actions/stale`, etc.) that do use hyphenated inputs. Those aren't affected.