### PR TITLE
test: add relay and heartbeat coverage

### DIFF
--- a/tests/test_heartbeat_assessments.py
+++ b/tests/test_heartbeat_assessments.py
@@ -1,0 +1,97 @@
+import json
+import tempfile
+import unittest
+from pathlib import Path
+from unittest.mock import patch
+
+from beacon_skill.heartbeat import (
+    DEFAULT_DEAD_THRESHOLD_S,
+    DEFAULT_SILENCE_THRESHOLD_S,
+    HEARTBEATS_FILE,
+    HeartbeatManager,
+)
+from beacon_skill.identity import AgentIdentity
+
+
+class TestHeartbeatAssessments(unittest.TestCase):
+    def test_build_heartbeat_increments_beat_count(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            data_dir = Path(tmpdir)
+            manager = HeartbeatManager(data_dir=data_dir, config={"_start_ts": 100})
+            identity = AgentIdentity.generate()
+
+            with patch("beacon_skill.heartbeat.time.time", return_value=200):
+                first = manager.build_heartbeat(identity, status="alive")
+            with patch("beacon_skill.heartbeat.time.time", return_value=260):
+                second = manager.build_heartbeat(identity, status="degraded")
+
+            self.assertEqual(first["beat_count"], 1)
+            self.assertEqual(second["beat_count"], 2)
+            self.assertEqual(second["status"], "degraded")
+            self.assertEqual(second["uptime_s"], 160)
+
+    def test_process_heartbeat_assesses_peer_health_by_age(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            data_dir = Path(tmpdir)
+            manager = HeartbeatManager(data_dir=data_dir)
+            envelope = {
+                "agent_id": "bcn_peer123456",
+                "beat_count": 1,
+                "status": "alive",
+                "name": "Peer Agent",
+                "uptime_s": 42,
+            }
+
+            with patch("beacon_skill.heartbeat.time.time", return_value=1000):
+                processed = manager.process_heartbeat(envelope)
+            self.assertEqual(processed["assessment"], "healthy")
+
+            with patch(
+                "beacon_skill.heartbeat.time.time",
+                return_value=1000 + DEFAULT_SILENCE_THRESHOLD_S + 5,
+            ):
+                peer = manager.peer_status("bcn_peer123456")
+            self.assertIsNotNone(peer)
+            self.assertEqual(peer["assessment"], "concerning")
+
+            with patch(
+                "beacon_skill.heartbeat.time.time",
+                return_value=1000 + DEFAULT_DEAD_THRESHOLD_S + 5,
+            ):
+                peer = manager.peer_status("bcn_peer123456")
+                all_peers = manager.all_peers(include_dead=True)
+                silent_peers = manager.silent_peers()
+            self.assertEqual(peer["assessment"], "presumed_dead")
+            self.assertEqual(all_peers[0]["assessment"], "presumed_dead")
+            self.assertEqual(silent_peers[0]["agent_id"], "bcn_peer123456")
+
+    def test_process_heartbeat_records_gap_and_health(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            data_dir = Path(tmpdir)
+            manager = HeartbeatManager(data_dir=data_dir)
+            first = {
+                "agent_id": "bcn_gappeer001",
+                "beat_count": 1,
+                "status": "alive",
+                "health": {"cpu": 0.1},
+            }
+            second = {
+                "agent_id": "bcn_gappeer001",
+                "beat_count": 2,
+                "status": "alive",
+                "health": {"cpu": 0.2},
+            }
+
+            with patch("beacon_skill.heartbeat.time.time", return_value=1000):
+                manager.process_heartbeat(first)
+            with patch("beacon_skill.heartbeat.time.time", return_value=1120):
+                manager.process_heartbeat(second)
+
+            state = json.loads((data_dir / HEARTBEATS_FILE).read_text(encoding="utf-8"))
+            peer = state["peers"]["bcn_gappeer001"]
+            self.assertEqual(peer["gap_s"], 120)
+            self.assertEqual(peer["health"], {"cpu": 0.2})
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_relay_heartbeat_and_registration.py
+++ b/tests/test_relay_heartbeat_and_registration.py
@@ -1,0 +1,70 @@
+import tempfile
+import unittest
+from pathlib import Path
+
+from beacon_skill.identity import AgentIdentity
+from beacon_skill.relay import RelayManager
+
+
+class TestRelayHeartbeatAndRegistration(unittest.TestCase):
+    def test_register_heartbeat_and_authenticate_round_trip(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            data_dir = Path(tmpdir)
+            manager = RelayManager(data_dir=data_dir)
+            identity = AgentIdentity.generate()
+
+            registered = manager.register(
+                pubkey_hex=identity.public_key_hex,
+                model_id="claude-opus-4-6",
+                provider="anthropic",
+                capabilities=["coding", "review"],
+                webhook_url="https://example.com/hook",
+                name="Nebula Runner",
+            )
+
+            self.assertTrue(registered["ok"])
+            self.assertEqual(registered["ttl_s"], 86400)
+            token = registered["relay_token"]
+            agent_id = registered["agent_id"]
+
+            agent = manager.authenticate(token)
+            self.assertIsNotNone(agent)
+            self.assertEqual(agent.agent_id, agent_id)
+            self.assertEqual(agent.provider, "anthropic")
+
+            heartbeat = manager.heartbeat(
+                agent_id,
+                token,
+                status="degraded",
+                health={"cpu": 0.73},
+            )
+            self.assertTrue(heartbeat["ok"])
+            self.assertEqual(heartbeat["beat_count"], 1)
+            self.assertEqual(heartbeat["status"], "degraded")
+            self.assertEqual(heartbeat["assessment"], "active")
+
+            public = manager.get_agent(agent_id)
+            self.assertIsNotNone(public)
+            self.assertEqual(public["status"], "active")
+            self.assertNotIn("relay_token", public)
+
+            discovered = manager.discover(provider="anthropic", capability="coding")
+            self.assertEqual(len(discovered), 1)
+            self.assertEqual(discovered[0]["agent_id"], agent_id)
+            self.assertEqual(discovered[0]["status"], "active")
+
+    def test_register_rejects_generic_name(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            manager = RelayManager(data_dir=Path(tmpdir))
+            result = manager.register(
+                pubkey_hex=("11" * 32),
+                model_id="grok-3",
+                provider="xai",
+                name="Grok Assistant",
+            )
+            self.assertIn("error", result)
+            self.assertIn("Generic AI model names", result["error"])
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- add heartbeat manager tests covering beat count, peer age assessment, and health/gap persistence
- add relay registration/authentication/heartbeat coverage for the external agent flow
- keep the new coverage focused on issue #152's heartbeat, relay, and trust surface

## Testing
- pytest -q tests/test_heartbeat_assessments.py tests/test_relay_heartbeat_and_registration.py tests/test_relay_status_assessment.py tests/test_trust.py

Fixes #152