### PR TITLE
fix: improve retry logic with precise HTTP code matching and max_delay cap

### DIFF
--- a/beacon_skill/retry.py
+++ b/beacon_skill/retry.py
@@ -23,6 +23,7 @@ def with_retry(
     *,
     max_attempts: int = 3,
     base_delay: float = 1.0,
+    max_delay: float = 60.0,
     jitter: bool = True,
     retryable_exceptions: Optional[tuple] = None,
 ) -> T:
@@ -36,6 +37,7 @@ def with_retry(
         fn: Zero-arg callable to retry.
         max_attempts: Total attempts (including the first).
         base_delay: Base delay in seconds (doubled each retry).
+        max_delay: Maximum delay cap in seconds (prevents excessive waits).
         jitter: Add random jitter to prevent thundering herd.
         retryable_exceptions: Extra exception types to retry on.
     """
@@ -60,19 +62,26 @@ def with_retry(
                 should_retry = True
 
             # Check for HTTP status codes in error message.
+            # Use precise pattern matching to avoid false positives
+            # (e.g., "429" could match error code 1429, port 8429, etc.)
             err_str = str(e)
             for code in RETRYABLE_STATUS_CODES:
-                if f"HTTP {code}" in err_str or f"{code}" in err_str:
+                # Match "HTTP 429", "status 429", "code 429", or ":429" patterns
+                if (f"HTTP {code}" in err_str or
+                    f"status {code}" in err_str.lower() or
+                    f"code {code}" in err_str.lower() or
+                    f":{code}" in err_str):
                     should_retry = True
                     break
 
             if not should_retry or attempt == max_attempts - 1:
                 raise
 
-            # Exponential backoff.
-            delay = base_delay * (2 ** attempt)
+            # Exponential backoff with jitter and max delay cap.
+            delay = min(base_delay * (2 ** attempt), max_delay)
             if jitter:
                 delay *= 0.5 + random.random()
+                delay = min(delay, max_delay)  # Re-cap after jitter
             time.sleep(delay)
 
     raise RetryError(last_error, max_attempts)


### PR DESCRIPTION
## Fix: Retry Logic Improvements

### Problem
The retry logic in `beacon_skill/retry.py` had two issues:

1. **False positive matching**: The pattern `f"{code}" in err_str` could match unrelated numbers (e.g., "429" matching error code 1429 or port 8429)
2. **No max delay cap**: Exponential backoff could result in excessively long delays (e.g., 1.0 * 2^10 = 1024 seconds)

### Solution
1. **Precise pattern matching**: Match specific patterns like "HTTP 429", "status 429", "code 429", or ":429"
2. **Max delay cap**: Added `max_delay` parameter (default 60s) to prevent excessive waits
3. **Re-cap after jitter**: Ensure jitter doesn't exceed max_delay

### Changes
- `beacon_skill/retry.py`: Improved HTTP status code matching
- Added `max_delay` parameter with 60s default
- Added better error message parsing

### Testing
- Pattern matching now correctly identifies HTTP status codes
- Max delay prevents excessive backoff waits
- Jitter still applied but capped at max_delay

**RTC Wallet:** RTC6d1f27d28961279f1034d9561c2403697eb55602