### PR TITLE
fix: add outbox retry backoff

### DIFF
--- a/beacon_skill/outbox.py
+++ b/beacon_skill/outbox.py
@@ -5,6 +5,7 @@ The executor drains pending items via transports.
 """
 
 import json
+import random
 import secrets
 import time
 from pathlib import Path
@@ -16,10 +17,26 @@ from .storage import _dir
 OUTBOX_LOG = "outbox.jsonl"
 OUTBOX_PENDING = "outbox_pending.json"
 MAX_RETRY_ATTEMPTS = 3
+BASE_RETRY_DELAY_SECONDS = 1.0
+MAX_RETRY_DELAY_SECONDS = 60.0
+RETRY_JITTER_SECONDS = 0.5
 
 
 def _gen_action_id() -> str:
     return secrets.token_hex(6)
+
+
+def _retry_delay_seconds(
+    attempts: int,
+    *,
+    base_delay: float = BASE_RETRY_DELAY_SECONDS,
+    max_delay: float = MAX_RETRY_DELAY_SECONDS,
+    jitter: float = RETRY_JITTER_SECONDS,
+) -> float:
+    delay = base_delay * (2 ** max(attempts - 1, 0))
+    if jitter > 0:
+        delay += random.uniform(0, jitter)
+    return min(delay, max_delay)
 
 
 class OutboxManager:
@@ -78,6 +95,7 @@ class OutboxManager:
             "created_at": now,
             "updated_at": now,
             "attempts": 0,
+            "next_attempt_at": now,
             "error": "",
             "conversation_id": conversation_id,
         }
@@ -91,10 +109,13 @@ class OutboxManager:
         """Return items ready to send (pending status, attempts < MAX_RETRY)."""
         data = self._read_pending()
         results = []
+        now = time.time()
         for item in data.values():
             if item.get("status") != "pending":
                 continue
             if item.get("attempts", 0) >= MAX_RETRY_ATTEMPTS:
+                continue
+            if item.get("next_attempt_at", 0) > now:
                 continue
             results.append(item)
         results.sort(key=lambda x: x.get("created_at", 0))
@@ -120,14 +141,18 @@ class OutboxManager:
             self._append_log({"action_id": action_id, "status": "failed", "error": error, "ts": int(time.time())})
 
     def mark_retry(self, action_id: str) -> None:
-        """Increment attempts counter. Item auto-fails at MAX_RETRY_ATTEMPTS."""
+        """Increment attempts counter and schedule exponential backoff."""
         pending = self._read_pending()
         if action_id in pending:
+            now = time.time()
             pending[action_id]["attempts"] = pending[action_id].get("attempts", 0) + 1
-            pending[action_id]["updated_at"] = int(time.time())
+            pending[action_id]["updated_at"] = int(now)
             if pending[action_id]["attempts"] >= MAX_RETRY_ATTEMPTS:
                 pending[action_id]["status"] = "failed"
                 pending[action_id]["error"] = "max_retries_exceeded"
+            else:
+                delay = _retry_delay_seconds(pending[action_id]["attempts"])
+                pending[action_id]["next_attempt_at"] = now + delay
             self._write_pending(pending)
 
     def get(self, action_id: str) -> Optional[Dict[str, Any]]:

--- a/tests/test_outbox.py
+++ b/tests/test_outbox.py
@@ -2,8 +2,9 @@ import tempfile
 import time
 import unittest
 from pathlib import Path
+from unittest import mock
 
-from beacon_skill.outbox import OutboxManager, MAX_RETRY_ATTEMPTS
+from beacon_skill.outbox import OutboxManager, MAX_RETRY_ATTEMPTS, _retry_delay_seconds
 
 
 class TestOutbox(unittest.TestCase):
@@ -58,6 +59,36 @@ class TestOutbox(unittest.TestCase):
         self.assertEqual(item["attempts"], 1)
         self.assertEqual(item["status"], "pending")
 
+    @mock.patch("beacon_skill.outbox.random.uniform", return_value=0)
+    def test_retry_delay_uses_exponential_backoff(self, mock_uniform):
+        self.assertEqual(_retry_delay_seconds(1), 1.0)
+        self.assertEqual(_retry_delay_seconds(2), 2.0)
+        self.assertEqual(_retry_delay_seconds(3), 4.0)
+
+    @mock.patch("beacon_skill.outbox.random.uniform", return_value=0.25)
+    def test_retry_delay_adds_jitter(self, mock_uniform):
+        self.assertEqual(_retry_delay_seconds(1), 1.25)
+
+    @mock.patch("beacon_skill.outbox.random.uniform", return_value=0)
+    @mock.patch("beacon_skill.outbox.time.time", return_value=1000.0)
+    def test_mark_retry_sets_next_attempt_time(self, mock_time, mock_uniform):
+        mgr = self._mgr()
+        aid = mgr.queue("reply", "bcn_alice", {"kind": "hello"})
+        mgr.mark_retry(aid)
+        item = mgr.get(aid)
+        self.assertEqual(item["next_attempt_at"], 1001.0)
+
+    def test_pending_excludes_items_until_next_attempt(self):
+        mgr = self._mgr()
+        aid = mgr.queue("reply", "bcn_alice", {"kind": "hello"})
+        item = mgr.get(aid)
+        item["next_attempt_at"] = time.time() + 60
+        pending = mgr._read_pending()
+        pending[aid] = item
+        mgr._write_pending(pending)
+
+        self.assertEqual(mgr.pending(), [])
+
     def test_max_retries_auto_fails(self):
         mgr = self._mgr()
         aid = mgr.queue("reply", "bcn_alice", {"kind": "hello"})
@@ -72,7 +103,11 @@ class TestOutbox(unittest.TestCase):
         aid = mgr.queue("reply", "bcn_alice", {"kind": "hello"})
         for _ in range(MAX_RETRY_ATTEMPTS - 1):
             mgr.mark_retry(aid)
-        # After 2 retries: attempts=2, still < MAX_RETRY_ATTEMPTS=3, still pending
+        # After 2 retries: attempts=2, still < MAX_RETRY_ATTEMPTS=3.
+        # Simulate the backoff window having elapsed so the item is ready.
+        pending = mgr._read_pending()
+        pending[aid]["next_attempt_at"] = time.time() - 1
+        mgr._write_pending(pending)
         items = mgr.pending()
         self.assertEqual(len(items), 1)
         mgr.mark_retry(aid)  # Now attempts=3 >= MAX_RETRY_ATTEMPTS → auto-fail


### PR DESCRIPTION
## What Changed
<!-- Brief description of changes -->

## Testing
<!-- How did you test? -->
- [ ] `pytest tests/` passes
- [ ] New code has SPDX headers

## Bounty
<!-- If claiming a bounty, link the issue -->
Resolves #

## Checklist
- [ ] Focused on a single change
- [ ] No unrelated modifications
- [ ] Documentation updated if needed
