### PR TITLE
fix(security): enable SSL verification by default with BEACON_VERIFY_SSL opt-out

### DIFF
--- a/atlas/seo_stats_broadcast.py
+++ b/atlas/seo_stats_broadcast.py
@@ -22,6 +22,10 @@ from typing import Dict, List
 RELAY_HOST = os.environ.get("BEACON_RELAY", "https://rustchain.org")
 BASE_URL = f"{RELAY_HOST}/beacon"
 
+VERIFY_SSL = os.environ.get("BEACON_VERIFY_SSL", "true").lower() not in ("false", "0", "no", "off")
+if not VERIFY_SSL:
+    print("  Warning: SSL certificate verification is DISABLED (BEACON_VERIFY_SSL=false)")
+
 
 def fetch_all_agents() -> List[Dict]:
     """Fetch native + relay agents from the directory page data."""
@@ -29,7 +33,7 @@ def fetch_all_agents() -> List[Dict]:
 
     # Relay agents via discover
     try:
-        resp = requests.get(f"{RELAY_HOST}/beacon/relay/discover?include_dead=true", timeout=10, verify=False)
+        resp = requests.get(f"{RELAY_HOST}/beacon/relay/discover?include_dead=true", timeout=10, verify=VERIFY_SSL)
         if resp.ok:
             relay = resp.json()
             if isinstance(relay, list):
@@ -41,7 +45,7 @@ def fetch_all_agents() -> List[Dict]:
 
     # Native agents — parse from sitemap
     try:
-        resp = requests.get(f"{BASE_URL}/sitemap.xml", timeout=10, verify=False)
+        resp = requests.get(f"{BASE_URL}/sitemap.xml", timeout=10, verify=VERIFY_SSL)
         if resp.ok:
             import re
             urls = re.findall(r"<loc>.*?/beacon/agent/([^<]+)</loc>", resp.text)
@@ -80,7 +84,7 @@ def check_agent_seo(agent_id: str) -> Dict:
 
     # Check HTML profile
     try:
-        resp = requests.get(f"{BASE_URL}/agent/{agent_id}", timeout=8, verify=False)
+        resp = requests.get(f"{BASE_URL}/agent/{agent_id}", timeout=8, verify=VERIFY_SSL)
         if resp.ok:
             html = resp.text
             stats["html_profile"] = True
@@ -101,14 +105,14 @@ def check_agent_seo(agent_id: str) -> Dict:
 
     # Check JSON profile
     try:
-        resp = requests.get(f"{BASE_URL}/agent/{agent_id}.json", timeout=5, verify=False)
+        resp = requests.get(f"{BASE_URL}/agent/{agent_id}.json", timeout=5, verify=VERIFY_SSL)
         stats["json_profile"] = resp.ok
     except Exception:
         pass
 
     # Check XML profile
     try:
-        resp = requests.get(f"{BASE_URL}/agent/{agent_id}.xml", timeout=5, verify=False)
+        resp = requests.get(f"{BASE_URL}/agent/{agent_id}.xml", timeout=5, verify=VERIFY_SSL)
         stats["xml_profile"] = resp.ok
     except Exception:
         pass
@@ -139,7 +143,7 @@ def check_directory_and_sitemap(agent_ids: List[str]) -> Dict[str, Dict[str, boo
     presence = {aid: {"in_directory": False, "in_sitemap": False, "in_llms_txt": False} for aid in agent_ids}
 
     try:
-        resp = requests.get(f"{BASE_URL}/directory", timeout=10, verify=False)
+        resp = requests.get(f"{BASE_URL}/directory", timeout=10, verify=VERIFY_SSL)
         if resp.ok:
             for aid in agent_ids:
                 if aid in resp.text:
@@ -148,7 +152,7 @@ def check_directory_and_sitemap(agent_ids: List[str]) -> Dict[str, Dict[str, boo
         pass
 
     try:
-        resp = requests.get(f"{BASE_URL}/sitemap.xml", timeout=10, verify=False)
+        resp = requests.get(f"{BASE_URL}/sitemap.xml", timeout=10, verify=VERIFY_SSL)
         if resp.ok:
             for aid in agent_ids:
                 if aid in resp.text:
@@ -157,7 +161,7 @@ def check_directory_and_sitemap(agent_ids: List[str]) -> Dict[str, Dict[str, boo
         pass
 
     try:
-        resp = requests.get(f"{BASE_URL}/llms.txt", timeout=10, verify=False)
+        resp = requests.get(f"{BASE_URL}/llms.txt", timeout=10, verify=VERIFY_SSL)
         if resp.ok:
             for aid in agent_ids:
                 if aid in resp.text:


### PR DESCRIPTION
## Summary

All equests calls in seo_stats_broadcast.py previously disabled SSL certificate verification with erify=False. This leaves the script vulnerable to **Man-in-the-Middle attacks**.

## Changes

- Replaced all 8 erify=False occurrences with erify=VERIFY_SSL
- Added VERIFY_SSL constant derived from BEACON_VERIFY_SSL env var (defaults to 	rue)
- Prints a warning when SSL verification is explicitly disabled
- Backward-compatible: existing behavior preserved if user sets BEACON_VERIFY_SSL=false

## Files Changed

- tlas/seo_stats_broadcast.py (+12 lines, -8 lines)

## Testing

- Verified no erify=False remains in the file
- Confirmed the script still runs with default env (SSL enabled)
- Confirmed opt-out works with BEACON_VERIFY_SSL=false

## Fixes

Fixes #827

/claim #386