### PR TITLE
test: cover storage JSONL edge cases (fixes #1589)

### DIFF
--- a/beacon_skill/storage.py
+++ b/beacon_skill/storage.py
@@ -73,9 +73,11 @@ def read_jsonl(name: str) -> List[Dict[str, Any]]:
         if not line:
             continue
         try:
-            results.append(json.loads(line))
+            item = json.loads(line)
         except Exception:
             continue
+        if isinstance(item, dict):
+            results.append(item)
     return results
 
 

--- a/tests/test_storage.py
+++ b/tests/test_storage.py
@@ -1,0 +1,59 @@
+import tempfile
+import unittest
+from pathlib import Path
+from unittest import mock
+
+from beacon_skill.storage import _safe_path, read_jsonl
+
+
+class TestStorage(unittest.TestCase):
+    def setUp(self):
+        self.tmpdir = tempfile.mkdtemp()
+        self.dir_patcher = mock.patch("beacon_skill.storage._dir", return_value=Path(self.tmpdir))
+        self.dir_patcher.start()
+
+    def tearDown(self):
+        self.dir_patcher.stop()
+        import shutil
+        shutil.rmtree(self.tmpdir, ignore_errors=True)
+
+    def test_read_jsonl_returns_empty_for_missing_file(self):
+        self.assertEqual(read_jsonl("missing.jsonl"), [])
+
+    def test_read_jsonl_skips_blank_invalid_and_non_object_lines(self):
+        path = Path(self.tmpdir) / "events.jsonl"
+        path.write_text(
+            '\n'.join([
+                '{"kind": "ok", "value": 1}',
+                '',
+                'not-json',
+                '[1, 2, 3]',
+                '"hello"',
+                '{"kind": "ok", "value": 2}',
+            ]) + '\n',
+            encoding="utf-8",
+        )
+
+        self.assertEqual(
+            read_jsonl("events.jsonl"),
+            [
+                {"kind": "ok", "value": 1},
+                {"kind": "ok", "value": 2},
+            ],
+        )
+
+    def test_safe_path_rejects_traversal_and_hidden_names(self):
+        for name in ("../state.json", "..\\state.json", ".hidden", "nested/file.json"):
+            with self.subTest(name=name):
+                with self.assertRaises(ValueError):
+                    _safe_path(name)
+
+    def test_safe_path_uses_beacon_inbox_path_override(self):
+        override = Path(self.tmpdir) / "nested" / "custom-inbox.jsonl"
+        with mock.patch.dict("os.environ", {"BEACON_INBOX_PATH": str(override)}, clear=False):
+            self.assertEqual(_safe_path("inbox.jsonl"), override)
+            self.assertTrue(override.parent.exists())
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- add focused storage tests for missing files, path safety, and inbox override behavior
- verify `read_jsonl()` skips blank lines, malformed JSON, and non-object JSON values
- tighten `read_jsonl()` so it only returns JSON objects, matching its typed contract

## Test Plan
- `pytest tests/test_storage.py -q`
- `pytest tests/test_storage.py tests/test_inbox.py -q`
- full `pytest -q` in this environment still shows unrelated pre-existing failures in `clawnews` and `discord` tests outside the touched area

Related: Scottcjn/rustchain-bounties#1589