### PR TITLE
fix: reject unauthenticated relay heartbeat registration (fixes #830)

### DIFF
--- a/atlas/beacon_chat.py
+++ b/atlas/beacon_chat.py
@@ -1149,34 +1149,10 @@ def relay_heartbeat():
     db = get_db()
     row = db.execute("SELECT * FROM relay_agents WHERE agent_id = ?", (agent_id,)).fetchone()
     if not row:
-        # AUTO-REGISTER: Create relay entry from heartbeat (beacon auto-discovery)
-        hb_name = data.get("name", "").strip() or agent_id
-        hb_caps = data.get("capabilities", [])
-        hb_provider = data.get("provider", "beacon").strip()
-        if hb_provider not in KNOWN_PROVIDERS:
-            hb_provider = "beacon"
-        hb_pubkey = data.get("pubkey_hex", "").strip() or secrets.token_hex(32)
-        auto_token = "relay_" + secrets.token_hex(24)
-        hb_ip = get_real_ip()
-        db.execute(
-            "INSERT INTO relay_agents"
-            " (agent_id, pubkey_hex, model_id, provider, capabilities, webhook_url,"
-            "  relay_token, token_expires, name, status, beat_count, registered_at, last_heartbeat, metadata, origin_ip)"
-            " VALUES (?,?,?,?,?,'',?,?,?,'active',1,?,?,?,?)",
-            (agent_id, hb_pubkey, hb_name, hb_provider,
-             json.dumps(hb_caps if isinstance(hb_caps, list) else []),
-             auto_token, now + RELAY_TOKEN_TTL_S, hb_name, now, now, json.dumps(profile_meta), hb_ip))
-        db.commit()
-        db.execute("INSERT INTO relay_log (ts, action, agent_id, detail) VALUES (?, 'auto_register', ?, ?)",
-                   (now, agent_id, json.dumps({"name": hb_name, "provider": hb_provider, "ip": hb_ip})))
-        db.commit()
         return cors_json({
-            "ok": True, "agent_id": agent_id, "beat_count": 1,
-            "status": status_val, "auto_registered": True,
-            "relay_token": auto_token,
-            "token_expires": now + RELAY_TOKEN_TTL_S,
-            "assessment": "healthy",
-        })
+            "error": "Unknown relay agent — register or ping with signed identity first",
+            "code": "UNKNOWN_AGENT",
+        }, 401)
 
     if row["relay_token"] != token:
         return cors_json({"error": "Invalid relay token", "code": "AUTH_FAILED"}, 403)

--- a/tests/test_relay_heartbeat_security.py
+++ b/tests/test_relay_heartbeat_security.py
@@ -1,0 +1,60 @@
+import sqlite3
+import sys
+from pathlib import Path
+
+import pytest
+
+
+ATLAS_DIR = Path(__file__).resolve().parents[1] / "atlas"
+if str(ATLAS_DIR) not in sys.path:
+    sys.path.insert(0, str(ATLAS_DIR))
+
+import beacon_chat
+
+
+@pytest.fixture()
+def client(monkeypatch):
+    workdir = Path(".test-artifacts")
+    workdir.mkdir(exist_ok=True)
+    db_path = workdir / "relay_heartbeat_security.db"
+    if db_path.exists():
+        db_path.unlink()
+
+    monkeypatch.setattr(beacon_chat, "DB_PATH", str(db_path), raising=False)
+    beacon_chat.ATLAS_RATE_LIMITER._entries.clear()
+    beacon_chat.ATLAS_RATE_LIMITER._last_cleanup = 0
+    beacon_chat.init_db()
+    yield beacon_chat.app.test_client()
+
+    if db_path.exists():
+        db_path.unlink()
+
+
+def test_relay_heartbeat_rejects_unknown_agent_even_with_bearer_token(client):
+    response = client.post(
+        "/relay/heartbeat",
+        json={
+            "agent_id": "bcn_victim_agent",
+            "status": "alive",
+            "name": "Spoofed Victim",
+            "provider": "openai",
+            "capabilities": ["wallet", "payment"],
+        },
+        headers={"Authorization": "Bearer attacker-controlled-garbage"},
+    )
+
+    assert response.status_code == 401
+    body = response.get_json()
+    assert body
+    assert "register" in body.get("error", "").lower() or "unknown" in body.get("error", "").lower()
+
+    conn = sqlite3.connect(beacon_chat.DB_PATH)
+    try:
+        row = conn.execute(
+            "SELECT relay_token FROM relay_agents WHERE agent_id = ?",
+            ("bcn_victim_agent",),
+        ).fetchone()
+    finally:
+        conn.close()
+
+    assert row is None


### PR DESCRIPTION
## Summary
- stop `/relay/heartbeat` from auto-registering unknown relay identities
- require unknown agents to register or ping with signed identity first
- add a regression test proving a junk Bearer token can no longer mint a relay identity/token

## Security impact
This closes an auth bypass where an attacker could call `/relay/heartbeat` with any Bearer token, auto-register a spoofed `agent_id`, receive a valid relay token, and then act as that fake relay identity.

## Test Plan
- `pytest tests/test_relay_heartbeat_security.py -q`
- `pytest tests/test_relay_ping_security.py tests/test_relay_register_security.py tests/test_relay_heartbeat_security.py -q`

Fixes #830