### PR TITLE
Fix RustChain branding in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -999,7 +999,7 @@ See [scorecard/README.md](scorecard/README.md) for full docs.
 
 **[Elyan Labs](https://github.com/Scottcjn)** · 1,882 commits · 97 repos · 1,334 stars · $0 raised
 
-[⭐ Star Rustchain](https://github.com/Scottcjn/Rustchain) · [📊 Q1 2026 Traction Report](https://github.com/Scottcjn/Rustchain/blob/main/docs/DEVELOPER_TRACTION_Q1_2026.md) · [Follow @Scottcjn](https://github.com/Scottcjn)
+[⭐ Star RustChain](https://github.com/Scottcjn/Rustchain) · [📊 Q1 2026 Traction Report](https://github.com/Scottcjn/Rustchain/blob/main/docs/DEVELOPER_TRACTION_Q1_2026.md) · [Follow @Scottcjn](https://github.com/Scottcjn)
 
 </div>
 


### PR DESCRIPTION
## Summary
- update README footer link text from "Star Rustchain" to "Star RustChain"
- keep the existing Scottcjn/Rustchain repository URL unchanged

## Validation
- git diff --check HEAD~1..HEAD
- duplicate check: no open beacon-skill PR or issue matched this RustChain capitalization fix
- duplicate check: #2178 comments only showed unrelated Beacon/version/link fixes and other-repo branding fixes before claim