### PR TITLE
Fix landing page GitHub link

### DIFF
--- a/docs/landing_page.html
+++ b/docs/landing_page.html
@@ -1337,7 +1337,7 @@ section { padding: 6rem 0; }
       </p>
       <div style="display:flex;gap:1rem;justify-content:center;flex-wrap:wrap;">
         <a href="#" class="btn btn-primary">Start Migration &#8594;</a>
-        <a href="https://github.com/rustchain/beacon-protocol" class="btn btn-secondary" target="_blank">View on GitHub</a>
+        <a href="https://github.com/Scottcjn/beacon-skill" class="btn btn-secondary" target="_blank">View on GitHub</a>
       </div>
     </div>
   </div>
@@ -1365,7 +1365,7 @@ section { padding: 6rem 0; }
         <h4>Resources</h4>
         <a href="https://docs.beaconprotocol.io" target="_blank">Documentation</a>
         <a href="https://blog.beaconprotocol.io" target="_blank">Blog</a>
-        <a href="https://github.com/rustchain/beacon-protocol" target="_blank">GitHub</a>
+        <a href="https://github.com/Scottcjn/beacon-skill" target="_blank">GitHub</a>
         <a href="#">API Reference</a>
       </div>
       <div class="footer-col">
@@ -1379,7 +1379,7 @@ section { padding: 6rem 0; }
     <div class="footer-bottom">
       <p>&copy; 2026 Beacon Protocol. Part of the RustChain Ecosystem. Open source under MIT License.</p>
       <div class="footer-socials">
-        <a href="https://github.com/rustchain/beacon-protocol" target="_blank" aria-label="GitHub">&#10042;</a>
+        <a href="https://github.com/Scottcjn/beacon-skill" target="_blank" aria-label="GitHub">&#10042;</a>
         <a href="https://docs.beaconprotocol.io" target="_blank" aria-label="Docs">&#128218;</a>
         <a href="https://blog.beaconprotocol.io" target="_blank" aria-label="Blog">&#9998;</a>
       </div>


### PR DESCRIPTION
## Summary
- update the landing page GitHub CTA/footer links from the missing `rustchain/beacon-protocol` repo to the live `Scottcjn/beacon-skill` repo
- keep the change scoped to docs/landing_page.html

## Validation
- `curl -L https://github.com/rustchain/beacon-protocol` returned 404
- `curl -L https://github.com/Scottcjn/beacon-skill` returned 200
- `git diff --check HEAD~1..HEAD`

Bounty: Scottcjn/rustchain-bounties#2178