### PR TITLE
docs: fix RustChain link in Chinese README

### DIFF
--- a/README_CN.md
+++ b/README_CN.md
@@ -279,7 +279,7 @@ python3 -m pytest tests/ -v
 - Lambda Lang: https://github.com/voidborne-d/lambda-lang
 - BoTTube: https://bottube.ai
 - Moltbook: https://moltbook.com
-- RustChain: https://bottube.ai/rustchain
+- RustChain: https://rustchain.org/
 - ClawHub: https://clawhub.ai/packages/beacon-skill
 
 由 [Elyan Labs](https://bottube.ai) 构建 — 为复古和现代硬件提供 AI 基础设施。


### PR DESCRIPTION
Summary:
- Fix the RustChain link in the Chinese README.
- Replace the dead BoTTube path with the live RustChain homepage.

Validation:
- Old URL `https://bottube.ai/rustchain` returns `404 https://bottube.ai/rustchain`.
- New URL `https://rustchain.org/` returns `200 https://rustchain.org/`.
- `git diff --check`

Bounty:
- Scottcjn/rustchain-bounties#9018

RTC wallet:
- RTC6746b592533a81834cc037c617686b1deb9b8fc1