### PR TITLE
fix: support storage locks on Windows

### DIFF
--- a/beacon_skill/storage.py
+++ b/beacon_skill/storage.py
@@ -1,10 +1,19 @@
-import fcntl
 import json
 import os
 import time
 from contextlib import contextmanager
 from pathlib import Path
-from typing import Any, Dict, List, Optional
+from typing import Any, Dict, IO, List, Optional
+
+try:
+    import fcntl as _fcntl
+except ImportError:  # pragma: no cover - exercised on Windows and by fallback tests
+    _fcntl = None
+
+try:
+    import msvcrt as _msvcrt
+except ImportError:  # pragma: no cover - exercised on POSIX
+    _msvcrt = None
 
 
 def _dir() -> Path:
@@ -30,16 +39,41 @@ def state_lock(write: bool = False):
     # Ensure lock file exists
     if not path.exists():
         path.touch()
-    
+
     # We use a separate lock file to avoid issues with opening/closing the JSON file itself
     with path.open("w") as f:
-        # LOCK_EX for write, LOCK_SH for read
-        mode = fcntl.LOCK_EX if write else fcntl.LOCK_SH
         try:
-            fcntl.flock(f, mode)
+            _lock_file(f, write=write)
             yield
         finally:
-            fcntl.flock(f, fcntl.LOCK_UN)
+            _unlock_file(f)
+
+
+def _lock_file(handle: IO[str], write: bool = False) -> None:
+    """Apply a best-effort advisory lock to ``handle`` on POSIX or Windows."""
+    if _fcntl is not None:
+        mode = _fcntl.LOCK_EX if write else _fcntl.LOCK_SH
+        _fcntl.flock(handle, mode)
+        return
+
+    if _msvcrt is not None:
+        handle.seek(0)
+        _msvcrt.locking(handle.fileno(), _msvcrt.LK_LOCK, 1)
+        return
+
+    raise RuntimeError("No supported file locking backend is available")
+
+
+def _unlock_file(handle: IO[str]) -> None:
+    """Release an advisory lock previously acquired by ``_lock_file``."""
+    if _fcntl is not None:
+        _fcntl.flock(handle, _fcntl.LOCK_UN)
+        return
+
+    if _msvcrt is not None:
+        handle.seek(0)
+        _msvcrt.locking(handle.fileno(), _msvcrt.LK_UNLCK, 1)
+        return
 
 
 def _safe_path(name: str) -> Path:

--- a/tests/test_storage_lock.py
+++ b/tests/test_storage_lock.py
@@ -1,0 +1,21 @@
+from beacon_skill import storage
+
+
+def test_state_lock_uses_windows_locking_fallback(monkeypatch, tmp_path):
+    calls = []
+
+    class FakeMsvcrt:
+        LK_LOCK = 1
+        LK_UNLCK = 2
+
+        def locking(self, fileno, mode, nbytes):
+            calls.append((mode, nbytes))
+
+    monkeypatch.setattr(storage, "_dir", lambda: tmp_path)
+    monkeypatch.setattr(storage, "_fcntl", None)
+    monkeypatch.setattr(storage, "_msvcrt", FakeMsvcrt())
+
+    with storage.state_lock(write=True):
+        assert (tmp_path / "state.json.lock").exists()
+
+    assert calls == [(FakeMsvcrt.LK_LOCK, 1), (FakeMsvcrt.LK_UNLCK, 1)]


### PR DESCRIPTION
## Description
Fixes Windows imports for `beacon_skill.storage` by making file locking backend selection portable:

- keeps the existing `fcntl.flock` path on POSIX
- uses `msvcrt.locking` for the lock file on Windows
- raises a clear runtime error only if neither backend is available
- adds a focused regression test for the Windows fallback path

Fixes Scottcjn/beacon-skill#835.

## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update

## Testing
- `python -c "import beacon_skill.storage; print('storage import ok')"`
- `python -m pytest tests\test_storage_lock.py tests\test_identity.py -q`
- `python -m pytest tests\test_storage_lock.py tests\test_heartbeat.py -q`
- `python -m pytest tests\test_cli_json_flag.py tests\test_storage_lock.py -q`
- `python -m beacon_skill.cli --help`
- `python -m compileall beacon_skill\storage.py tests\test_storage_lock.py`
- `git diff --check`

## Checklist
- [x] My code follows the style guidelines
- [x] I have performed a self-review
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have tested changes locally

## Bounty Claim
If this PR addresses a bounty issue:
- Issue number: Scottcjn/Rustchain#305 and Scottcjn/beacon-skill#835
- Wallet ID: cerredz
