### PR TITLE
fix: require registration before relay heartbeats

### DIFF
--- a/atlas/beacon_chat.py
+++ b/atlas/beacon_chat.py
@@ -1149,34 +1149,11 @@ def relay_heartbeat():
     db = get_db()
     row = db.execute("SELECT * FROM relay_agents WHERE agent_id = ?", (agent_id,)).fetchone()
     if not row:
-        # AUTO-REGISTER: Create relay entry from heartbeat (beacon auto-discovery)
-        hb_name = data.get("name", "").strip() or agent_id
-        hb_caps = data.get("capabilities", [])
-        hb_provider = data.get("provider", "beacon").strip()
-        if hb_provider not in KNOWN_PROVIDERS:
-            hb_provider = "beacon"
-        hb_pubkey = data.get("pubkey_hex", "").strip() or secrets.token_hex(32)
-        auto_token = "relay_" + secrets.token_hex(24)
-        hb_ip = get_real_ip()
-        db.execute(
-            "INSERT INTO relay_agents"
-            " (agent_id, pubkey_hex, model_id, provider, capabilities, webhook_url,"
-            "  relay_token, token_expires, name, status, beat_count, registered_at, last_heartbeat, metadata, origin_ip)"
-            " VALUES (?,?,?,?,?,'',?,?,?,'active',1,?,?,?,?)",
-            (agent_id, hb_pubkey, hb_name, hb_provider,
-             json.dumps(hb_caps if isinstance(hb_caps, list) else []),
-             auto_token, now + RELAY_TOKEN_TTL_S, hb_name, now, now, json.dumps(profile_meta), hb_ip))
-        db.commit()
-        db.execute("INSERT INTO relay_log (ts, action, agent_id, detail) VALUES (?, 'auto_register', ?, ?)",
-                   (now, agent_id, json.dumps({"name": hb_name, "provider": hb_provider, "ip": hb_ip})))
-        db.commit()
         return cors_json({
-            "ok": True, "agent_id": agent_id, "beat_count": 1,
-            "status": status_val, "auto_registered": True,
-            "relay_token": auto_token,
-            "token_expires": now + RELAY_TOKEN_TTL_S,
-            "assessment": "healthy",
-        })
+            "error": "Agent not registered",
+            "hint": "Register with /relay/register or signed /relay/ping before sending heartbeats",
+            "code": "AGENT_NOT_REGISTERED",
+        }, 404)
 
     if row["relay_token"] != token:
         return cors_json({"error": "Invalid relay token", "code": "AUTH_FAILED"}, 403)

--- a/tests/test_relay_heartbeat_security.py
+++ b/tests/test_relay_heartbeat_security.py
@@ -1,0 +1,93 @@
+import tempfile
+import time
+import unittest
+
+from atlas import beacon_chat
+
+
+class TestRelayHeartbeatSecurity(unittest.TestCase):
+    def setUp(self) -> None:
+        self._tmp = tempfile.TemporaryDirectory()
+        self._orig_db_path = beacon_chat.DB_PATH
+        beacon_chat.DB_PATH = f"{self._tmp.name}/beacon_atlas_test.db"
+        beacon_chat.ATLAS_RATE_LIMITER._entries.clear()
+        beacon_chat.ATLAS_RATE_LIMITER._last_cleanup = 0.0
+        beacon_chat.init_db()
+        beacon_chat.app.config["TESTING"] = True
+        self.client = beacon_chat.app.test_client()
+
+    def tearDown(self) -> None:
+        beacon_chat.DB_PATH = self._orig_db_path
+        self._tmp.cleanup()
+
+    def test_relay_heartbeat_rejects_unknown_agent_with_bearer_token(self) -> None:
+        response = self.client.post(
+            "/relay/heartbeat",
+            headers={"Authorization": "Bearer attacker-controlled-garbage"},
+            json={
+                "agent_id": "bcn_attacker001",
+                "status": "alive",
+                "name": "Attacker",
+                "capabilities": ["relay"],
+            },
+        )
+
+        self.assertEqual(response.status_code, 404)
+        payload = response.get_json()
+        self.assertEqual(payload["code"], "AGENT_NOT_REGISTERED")
+        self.assertNotIn("relay_token", payload)
+
+        with beacon_chat.app.app_context():
+            db = beacon_chat.get_db()
+            row = db.execute(
+                "SELECT agent_id FROM relay_agents WHERE agent_id = ?",
+                ("bcn_attacker001",),
+            ).fetchone()
+        self.assertIsNone(row)
+
+    def test_relay_heartbeat_accepts_registered_agent_with_valid_token(self) -> None:
+        now = time.time()
+        with beacon_chat.app.app_context():
+            db = beacon_chat.get_db()
+            db.execute(
+                """
+                INSERT INTO relay_agents (
+                    agent_id, pubkey_hex, model_id, provider, capabilities, webhook_url,
+                    relay_token, token_expires, name, status, beat_count, registered_at,
+                    last_heartbeat, metadata
+                ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+                """,
+                (
+                    "bcn_registered1",
+                    "11" * 32,
+                    "test-model",
+                    "beacon",
+                    "[]",
+                    "",
+                    "relay_valid_token",
+                    now + 3600,
+                    "Registered Agent",
+                    "active",
+                    1,
+                    now,
+                    now,
+                    "{}",
+                ),
+            )
+            db.commit()
+
+        response = self.client.post(
+            "/relay/heartbeat",
+            headers={"Authorization": "Bearer relay_valid_token"},
+            json={"agent_id": "bcn_registered1", "status": "alive"},
+        )
+
+        self.assertEqual(response.status_code, 200)
+        payload = response.get_json()
+        self.assertTrue(payload["ok"])
+        self.assertEqual(payload["beat_count"], 2)
+        self.assertNotIn("relay_token", payload)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Description
Fixes the auth bypass reported in #830 by making `/relay/heartbeat` fail closed for unknown agents.

Before this change, an unknown `agent_id` with any `Authorization: Bearer ...` value was auto-registered and issued a fresh relay token. After this change, `/relay/heartbeat` only updates already-registered agents with a valid relay token. New agents must use `/relay/register` or the signed `/relay/ping` registration path.

Fixes #830.

## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update

## Testing
- `python -m pytest tests\test_relay_heartbeat_security.py -q` with a temporary in-process `fcntl` shim for local Windows verification, because upstream `main` still has the Windows `fcntl` import crash fixed separately in #836
- `python -m pytest tests\test_relay_ping_security.py tests\test_relay_heartbeat_security.py -q` with the same temporary local shim
- `python -m py_compile atlas\beacon_chat.py tests\test_relay_heartbeat_security.py`
- `git diff --check`

## Checklist
- [x] My code follows the style guidelines
- [x] I have performed a self-review
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have tested changes locally

## Bounty Claim
If this PR addresses a bounty issue:
- Issue number: #830 and Scottcjn/Rustchain#305
- Wallet ID: cerredz
