### PR TITLE
feat(relay): add inbox_count and relay_log_count to stats export

### DIFF
--- a/beacon_skill/relay.py
+++ b/beacon_skill/relay.py
@@ -19,7 +19,7 @@ from pathlib import Path
 from typing import Any, Dict, List, Optional
 
 from .identity import AgentIdentity, agent_id_from_pubkey
-from .storage import _dir, append_jsonl, read_jsonl_tail
+from .storage import _dir, append_jsonl, read_jsonl_tail, jsonl_count
 
 RELAY_STATE_FILE = "relay_agents.json"
 RELAY_LOG_FILE = "relay_log.jsonl"
@@ -524,5 +524,7 @@ class RelayManager:
             "silent": silent,
             "presumed_dead": dead,
             "by_provider": by_provider,
+            "inbox_count": jsonl_count("inbox.jsonl"),
+            "relay_log_count": jsonl_count(RELAY_LOG_FILE),
             "ts": now,
         }


### PR DESCRIPTION
## Summary

Adds two new fields to the relay stats JSON export:
- : total messages forwarded via relay  
- : total relay log entries

These metrics are useful for monitoring relay throughput and message volume without exposing internal agent data.

## Changes

Modified :
- Import  from storage
- Add  and  fields to 

## Testing

```bash
beacon relay stats
# Now outputs:
# {
#   "total_agents": 0,
#   "active": 0,
#   "inbox_count": 0,
#   "relay_log_count": 0,
#   ...
# }
```

This addresses issue #818: CLI tool to export relay metrics as JSON for monitoring tools integration.