### PR TITLE
Fix landing page GitHub links

### DIFF
--- a/docs/landing_page.html
+++ b/docs/landing_page.html
@@ -1337,7 +1337,7 @@ section { padding: 6rem 0; }
       </p>
       <div style="display:flex;gap:1rem;justify-content:center;flex-wrap:wrap;">
         <a href="#" class="btn btn-primary">Start Migration &#8594;</a>
-        <a href="https://github.com/rustchain/beacon-protocol" class="btn btn-secondary" target="_blank">View on GitHub</a>
+        <a href="https://github.com/Scottcjn/beacon-skill" class="btn btn-secondary" target="_blank">View on GitHub</a>
       </div>
     </div>
   </div>
@@ -1363,9 +1363,9 @@ section { padding: 6rem 0; }
       </div>
       <div class="footer-col">
         <h4>Resources</h4>
-        <a href="https://docs.beaconprotocol.io" target="_blank">Documentation</a>
-        <a href="https://blog.beaconprotocol.io" target="_blank">Blog</a>
-        <a href="https://github.com/rustchain/beacon-protocol" target="_blank">GitHub</a>
+        <a href="https://github.com/Scottcjn/beacon-skill#readme" target="_blank">Documentation</a>
+        <a href="https://dev.to/scottcjn" target="_blank">Blog</a>
+        <a href="https://github.com/Scottcjn/beacon-skill" target="_blank">GitHub</a>
         <a href="#">API Reference</a>
       </div>
       <div class="footer-col">
@@ -1379,9 +1379,9 @@ section { padding: 6rem 0; }
     <div class="footer-bottom">
       <p>&copy; 2026 Beacon Protocol. Part of the RustChain Ecosystem. Open source under MIT License.</p>
       <div class="footer-socials">
-        <a href="https://github.com/rustchain/beacon-protocol" target="_blank" aria-label="GitHub">&#10042;</a>
-        <a href="https://docs.beaconprotocol.io" target="_blank" aria-label="Docs">&#128218;</a>
-        <a href="https://blog.beaconprotocol.io" target="_blank" aria-label="Blog">&#9998;</a>
+        <a href="https://github.com/Scottcjn/beacon-skill" target="_blank" aria-label="GitHub">&#10042;</a>
+        <a href="https://github.com/Scottcjn/beacon-skill#readme" target="_blank" aria-label="Docs">&#128218;</a>
+        <a href="https://dev.to/scottcjn" target="_blank" aria-label="Blog">&#9998;</a>
       </div>
     </div>
   </div>


### PR DESCRIPTION
## Summary
- Replace three stale landing page GitHub links that point to `github.com/rustchain/beacon-protocol`
- Replace unreachable `docs.beaconprotocol.io` and `blog.beaconprotocol.io` footer links with live project resources
- Point documentation to the repository README and blog content to the maintainer Dev.to profile

## Validation
- Old GitHub link returns HTTP 404
- `docs.beaconprotocol.io` and `blog.beaconprotocol.io` fail to resolve/respond from this environment
- New GitHub/README and Dev.to links return HTTP 200
- Parsed `docs/landing_page.html` with Python `html.parser`
- `git diff --check` passes
