### PR TITLE
Persist Atlas relay tokens for restart-safe heartbeats

### DIFF
--- a/beacon_skill/atlas_ping.py
+++ b/beacon_skill/atlas_ping.py
@@ -11,26 +11,76 @@ Beacon 2.15.0 — Elyan Labs.
 """
 
 import time
+from pathlib import Path
 from typing import Any, Dict, List, Optional
+import json
+import os
 
 import requests
 
 DEFAULT_ATLAS_URL = "https://rustchain.org/beacon"
 ATLAS_PING_INTERVAL_S = 600  # 10 minutes
+TOKEN_FILE_NAME = "atlas_relay_token.json"
 
 # Store relay token between calls
 _relay_token: Optional[str] = None
 
 
+def _token_path() -> Path:
+    """Return the per-user Atlas relay token path."""
+    return Path.home() / ".beacon" / TOKEN_FILE_NAME
+
+
+def _load_token_from_disk() -> Optional[str]:
+    """Load a previously issued Atlas relay token if it is still usable."""
+    path = _token_path()
+    if not path.exists():
+        return None
+    try:
+        data = json.loads(path.read_text(encoding="utf-8"))
+    except Exception:
+        return None
+
+    token = data.get("relay_token")
+    expires = int(data.get("token_expires") or 0)
+    if not token:
+        return None
+    if expires and expires <= int(time.time()):
+        return None
+    return str(token)
+
+
+def _save_token_to_disk(token: str, token_expires: Optional[int] = None) -> None:
+    """Persist the Atlas relay token for daemon restarts."""
+    path = _token_path()
+    path.parent.mkdir(parents=True, exist_ok=True)
+    payload: Dict[str, Any] = {
+        "relay_token": token,
+        "saved_at": int(time.time()),
+    }
+    if token_expires:
+        payload["token_expires"] = int(token_expires)
+    path.write_text(json.dumps(payload, indent=2) + "\n", encoding="utf-8")
+    try:
+        os.chmod(path, 0o600)
+    except Exception:
+        pass
+
+
 def get_stored_token() -> Optional[str]:
     """Get the stored relay token."""
+    global _relay_token
+    if _relay_token:
+        return _relay_token
+    _relay_token = _load_token_from_disk()
     return _relay_token
 
 
-def set_stored_token(token: str) -> None:
+def set_stored_token(token: str, token_expires: Optional[int] = None) -> None:
     """Store the relay token for future heartbeats."""
     global _relay_token
     _relay_token = token
+    _save_token_to_disk(token, token_expires)
 
 
 def atlas_ping(
@@ -76,8 +126,9 @@ def atlas_ping(
         body["preferred_city"] = preferred_city
 
     # Check if we have a relay token (existing agent heartbeat)
-    if _relay_token:
-        body["relay_token"] = _relay_token
+    stored_token = get_stored_token()
+    if stored_token:
+        body["relay_token"] = stored_token
     elif identity:
         # New agent registration - sign the agent_id
         try:
@@ -100,7 +151,7 @@ def atlas_ping(
             result = resp.json()
             # Store relay token for future heartbeats
             if result.get("relay_token"):
-                set_stored_token(result["relay_token"])
+                set_stored_token(result["relay_token"], result.get("token_expires"))
             return result
         return {"ok": False, "error": f"HTTP {resp.status_code}", "body": resp.text[:200]}
     except Exception as exc:

--- a/tests/test_atlas_ping_token.py
+++ b/tests/test_atlas_ping_token.py
@@ -1,0 +1,111 @@
+import json
+import importlib
+import time
+from pathlib import Path
+from unittest.mock import patch
+
+from beacon_skill.atlas_ping import atlas_ping_with_identity, get_stored_token
+from beacon_skill.identity import AgentIdentity
+
+atlas_ping_module = importlib.import_module("beacon_skill.atlas_ping")
+
+
+class _FakeResponse:
+    def __init__(self, payload, ok=True, status_code=200, text=""):
+        self._payload = payload
+        self.ok = ok
+        self.status_code = status_code
+        self.text = text
+
+    def json(self):
+        return self._payload
+
+
+def test_atlas_ping_persists_relay_token_for_next_process(tmp_path, monkeypatch):
+    monkeypatch.setenv("HOME", str(tmp_path))
+    atlas_ping_module._relay_token = None
+    identity = AgentIdentity.generate()
+    post_calls = []
+
+    def fake_post(url, json=None, timeout=10):
+        post_calls.append(json)
+        return _FakeResponse(
+            {
+                "ok": True,
+                "agent_id": identity.agent_id,
+                "relay_token": "relay_persisted_token",
+                "token_expires": int(time.time()) + 3600,
+            }
+        )
+
+    with patch("beacon_skill.atlas_ping.requests.post", side_effect=fake_post):
+        result = atlas_ping_with_identity(identity, name="Persisted Token Agent")
+
+    assert result["ok"] is True
+    token_path = tmp_path / ".beacon" / "atlas_relay_token.json"
+    token_data = json.loads(token_path.read_text(encoding="utf-8"))
+    assert token_data["relay_token"] == "relay_persisted_token"
+    assert oct(token_path.stat().st_mode & 0o777) == "0o600"
+
+    atlas_ping_module._relay_token = None
+    assert get_stored_token() == "relay_persisted_token"
+    assert "signature" in post_calls[0]
+
+
+def test_atlas_ping_uses_persisted_token_instead_of_resigning(tmp_path, monkeypatch):
+    monkeypatch.setenv("HOME", str(tmp_path))
+    token_dir = tmp_path / ".beacon"
+    token_dir.mkdir()
+    (token_dir / "atlas_relay_token.json").write_text(
+        json.dumps(
+            {
+                "relay_token": "relay_existing_token",
+                "token_expires": int(time.time()) + 3600,
+            }
+        ),
+        encoding="utf-8",
+    )
+    atlas_ping_module._relay_token = None
+    identity = AgentIdentity.generate()
+    post_calls = []
+
+    def fake_post(url, json=None, timeout=10):
+        post_calls.append(json)
+        return _FakeResponse({"ok": True, "agent_id": identity.agent_id, "beat_count": 2})
+
+    with patch("beacon_skill.atlas_ping.requests.post", side_effect=fake_post):
+        result = atlas_ping_with_identity(identity, name="Persisted Token Agent")
+
+    assert result["ok"] is True
+    assert post_calls[0]["relay_token"] == "relay_existing_token"
+    assert "signature" not in post_calls[0]
+    assert "pubkey_hex" not in post_calls[0]
+
+
+def test_expired_persisted_token_is_ignored(tmp_path, monkeypatch):
+    monkeypatch.setenv("HOME", str(tmp_path))
+    token_dir = tmp_path / ".beacon"
+    token_dir.mkdir()
+    Path(token_dir / "atlas_relay_token.json").write_text(
+        json.dumps(
+            {
+                "relay_token": "relay_expired_token",
+                "token_expires": int(time.time()) - 1,
+            }
+        ),
+        encoding="utf-8",
+    )
+    atlas_ping_module._relay_token = None
+    identity = AgentIdentity.generate()
+    post_calls = []
+
+    def fake_post(url, json=None, timeout=10):
+        post_calls.append(json)
+        return _FakeResponse({"ok": True, "agent_id": identity.agent_id})
+
+    with patch("beacon_skill.atlas_ping.requests.post", side_effect=fake_post):
+        result = atlas_ping_with_identity(identity, name="Persisted Token Agent")
+
+    assert result["ok"] is True
+    assert "relay_token" not in post_calls[0]
+    assert "signature" in post_calls[0]


### PR DESCRIPTION
## Summary
- Persist Atlas relay tokens in `~/.beacon/atlas_relay_token.json` with 0600 permissions
- Reuse a valid persisted token before falling back to signed first-registration mode
- Ignore expired or malformed token files so agents can recover by signing a fresh registration
- Add focused tests for token persistence, restart reuse, and expired-token fallback

## Why
This fixes a client-side part of rustchain-bounties#2127: after an agent auto-registers through `/beacon/relay/ping`, the returned relay token was only stored in memory. A daemon restart or new CLI process then loses the token, and existing-agent heartbeats fail with `relay_token required for existing agent heartbeat`. Persisting the token lets auto-registered agents remain active after restarts.

## Validation
- `uv run --no-project --with pytest --with requests --with cryptography python -m pytest tests/test_atlas_ping_token.py` -> 3 passed
- `python3 -m py_compile beacon_skill/atlas_ping.py tests/test_atlas_ping_token.py`
- `git diff --check`

## Note
This is a focused client-side heartbeat persistence fix. The VPS/nginx routing acceptance criteria in rustchain-bounties#2127 still require server-side access/configuration.