### PR TITLE
Add BoTTube API smoke-test example

### DIFF
--- a/beacon_skill/transports/bottube.py
+++ b/beacon_skill/transports/bottube.py
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: MIT
 import json
 from typing import Any, Dict, Optional
 
@@ -52,6 +53,32 @@ class BoTTubeClient:
             return data
 
         return with_retry(_do)
+
+    def health(self) -> Dict[str, Any]:
+        """Return BoTTube service health and public platform counters."""
+        return self._request("GET", "/health", auth=False)
+
+    def list_videos(self, limit: int = 5, offset: int = 0, **filters: Any) -> Dict[str, Any]:
+        """List public BoTTube videos."""
+        params: Dict[str, Any] = {"limit": limit, "offset": offset}
+        params.update(filters)
+        return self._request("GET", "/api/videos", auth=False, params=params)
+
+    def feed(self, limit: int = 5, offset: int = 0, **filters: Any) -> Dict[str, Any]:
+        """Read the public BoTTube feed."""
+        params: Dict[str, Any] = {"limit": limit, "offset": offset}
+        params.update(filters)
+        return self._request("GET", "/api/feed", auth=False, params=params)
+
+    def upload_video(self, video_url: str, title: str, description: str = "", **metadata: Any) -> Dict[str, Any]:
+        """Upload/register a video on BoTTube using an API key."""
+        payload: Dict[str, Any] = {
+            "video_url": video_url,
+            "title": title,
+            "description": description,
+        }
+        payload.update(metadata)
+        return self._request("POST", "/api/upload", auth=True, json=payload)
 
     def get_agent(self, agent_name: str) -> Dict[str, Any]:
         return self._request("GET", f"/api/agents/{agent_name}", auth=False)
@@ -121,4 +148,3 @@ class BoTTubeClient:
             results["actions"]["tip"] = self.tip_video(video_id, tip_amount, tip_message)
 
         return results
-

--- a/examples/bottube_api_example.py
+++ b/examples/bottube_api_example.py
@@ -1,0 +1,108 @@
+# SPDX-License-Identifier: MIT
+"""BoTTube API integration example for Beacon agents.
+
+This example calls the public BoTTube endpoints that agent builders usually
+need first:
+
+- GET /health
+- GET /api/videos
+- GET /api/feed
+
+Authenticated upload support is shown with ``--upload-dry-run`` so developers
+can verify their payload before sending it with a real ``BOTTUBE_API_KEY``.
+
+Docs:
+- https://bottube.ai/developers
+- https://bottube.ai/api/docs
+
+Run:
+    python examples/bottube_api_example.py --limit 1
+
+Optional upload payload preview:
+    python examples/bottube_api_example.py --upload-dry-run \
+      --video-url https://example.com/demo.mp4 \
+      --title "Beacon demo"
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import sys
+from pathlib import Path
+from typing import Any, Dict
+
+
+if __package__ is None or __package__ == "":
+    sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+from beacon_skill.transports.bottube import BoTTubeClient
+
+
+def _compact_sample(payload: Dict[str, Any]) -> Dict[str, Any]:
+    """Keep proof output readable while preserving the response shape."""
+    compact: Dict[str, Any] = {}
+    for key, value in payload.items():
+        if isinstance(value, list):
+            compact[key] = {
+                "count": len(value),
+                "first": value[0] if value else None,
+            }
+        else:
+            compact[key] = value
+    return compact
+
+
+def build_upload_payload(args: argparse.Namespace) -> Dict[str, Any]:
+    return {
+        "video_url": args.video_url,
+        "title": args.title,
+        "description": args.description,
+        "tags": [tag.strip() for tag in args.tags.split(",") if tag.strip()],
+        "source": "beacon-skill-example",
+    }
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description="Run a BoTTube API smoke test from Beacon")
+    parser.add_argument("--base-url", default=os.getenv("BOTTUBE_API_URL", "https://bottube.ai"))
+    parser.add_argument("--limit", type=int, default=2, help="Number of feed/video items to request")
+    parser.add_argument("--api-key", default=os.getenv("BOTTUBE_API_KEY"))
+    parser.add_argument("--upload-dry-run", action="store_true", help="Print an /api/upload payload without sending it")
+    parser.add_argument("--upload", action="store_true", help="Send /api/upload with BOTTUBE_API_KEY")
+    parser.add_argument("--video-url", default="https://example.com/beacon-demo.mp4")
+    parser.add_argument("--title", default="Beacon BoTTube API example")
+    parser.add_argument("--description", default="Beacon agent example upload payload")
+    parser.add_argument("--tags", default="beacon,agent,bottube")
+    args = parser.parse_args()
+
+    client = BoTTubeClient(base_url=args.base_url, api_key=args.api_key)
+
+    health = client.health()
+    videos = client.list_videos(limit=args.limit)
+    feed = client.feed(limit=args.limit)
+
+    proof = {
+        "docs": [
+            "https://bottube.ai/developers",
+            "https://bottube.ai/api/docs",
+        ],
+        "GET /health": {"ok": True, "sample": _compact_sample(health)},
+        f"GET /api/videos?limit={args.limit}": {"ok": True, "sample": _compact_sample(videos)},
+        f"GET /api/feed?limit={args.limit}": {"ok": True, "sample": _compact_sample(feed)},
+    }
+
+    if args.upload_dry_run or args.upload:
+        payload = build_upload_payload(args)
+        if args.upload:
+            proof["POST /api/upload"] = {"ok": True, "sample": client.upload_video(**payload)}
+        else:
+            proof["POST /api/upload dry_run"] = {"ok": True, "payload": payload}
+
+    print(json.dumps(proof, indent=2, sort_keys=True, ensure_ascii=False))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_bottube_transport.py
+++ b/tests/test_bottube_transport.py
@@ -1,0 +1,60 @@
+# SPDX-License-Identifier: MIT
+from unittest.mock import Mock, patch
+
+import pytest
+
+from beacon_skill.transports.bottube import BoTTubeClient, BoTTubeError
+
+
+def _mock_response(status_code=200, json_data=None, text=""):
+    resp = Mock()
+    resp.status_code = status_code
+    resp.text = text or str(json_data or "")
+    if json_data is not None:
+        resp.json.return_value = json_data
+    else:
+        resp.json.side_effect = ValueError("no JSON")
+    return resp
+
+
+def test_health_calls_public_endpoint():
+    client = BoTTubeClient()
+    with patch.object(client.session, "request") as request:
+        request.return_value = _mock_response(json_data={"ok": True})
+        assert client.health() == {"ok": True}
+    request.assert_called_once()
+    assert request.call_args.args[:2] == ("GET", "https://bottube.ai/health")
+
+
+def test_list_videos_passes_limit_and_offset():
+    client = BoTTubeClient()
+    with patch.object(client.session, "request") as request:
+        request.return_value = _mock_response(json_data={"videos": []})
+        client.list_videos(limit=3, offset=6, agent="sophia")
+    assert request.call_args.args[:2] == ("GET", "https://bottube.ai/api/videos")
+    assert request.call_args.kwargs["params"] == {"limit": 3, "offset": 6, "agent": "sophia"}
+
+
+def test_feed_calls_public_endpoint():
+    client = BoTTubeClient()
+    with patch.object(client.session, "request") as request:
+        request.return_value = _mock_response(json_data={"items": []})
+        client.feed(limit=1)
+    assert request.call_args.args[:2] == ("GET", "https://bottube.ai/api/feed")
+    assert request.call_args.kwargs["params"] == {"limit": 1, "offset": 0}
+
+
+def test_upload_requires_api_key():
+    client = BoTTubeClient()
+    with pytest.raises(BoTTubeError, match="API key required"):
+        client.upload_video("https://example.com/v.mp4", "Demo")
+
+
+def test_upload_uses_x_api_key_header():
+    client = BoTTubeClient(api_key="bt_test")
+    with patch.object(client.session, "request") as request:
+        request.return_value = _mock_response(json_data={"ok": True})
+        client.upload_video("https://example.com/v.mp4", "Demo", tags=["beacon"])
+    assert request.call_args.args[:2] == ("POST", "https://bottube.ai/api/upload")
+    assert request.call_args.kwargs["headers"]["X-API-Key"] == "bt_test"
+    assert request.call_args.kwargs["json"]["video_url"] == "https://example.com/v.mp4"


### PR DESCRIPTION
## Summary
- add public BoTTube client helpers for /health, /api/videos, and /api/feed
- add an examples/bottube_api_example.py smoke test with setup docs and official BoTTube links
- add unit coverage for public calls and authenticated /api/upload payload handling

## Bounty fit
This targets rustchain-bounties #303 by adding a working BoTTube API example to the existing Beacon agent framework. The example includes setup instructions and links to:
- https://bottube.ai/developers
- https://bottube.ai/api/docs

## Verification
- . .venv/bin/activate && python -m pytest tests/test_bottube_transport.py -q
- . .venv/bin/activate && python examples/bottube_api_example.py --limit 1 --upload-dry-run

Live smoke-test output included successful responses for:
- GET /health
- GET /api/videos?limit=1
- GET /api/feed?limit=1
- POST /api/upload dry-run payload