### PR TITLE
test: cover Windows storage lock fallback

### DIFF
--- a/tests/test_storage.py
+++ b/tests/test_storage.py
@@ -3,7 +3,7 @@ import unittest
 from pathlib import Path
 from unittest import mock
 
-from beacon_skill.storage import _safe_path, read_jsonl
+from beacon_skill.storage import _safe_path, append_jsonl, read_jsonl, state_lock
 
 
 class TestStorage(unittest.TestCase):
@@ -53,6 +53,16 @@ class TestStorage(unittest.TestCase):
         with mock.patch.dict("os.environ", {"BEACON_INBOX_PATH": str(override)}, clear=False):
             self.assertEqual(_safe_path("inbox.jsonl"), override)
             self.assertTrue(override.parent.exists())
+
+    def test_state_lock_allows_non_posix_fallback(self):
+        with mock.patch("beacon_skill.storage._HAVE_FCNTL", False):
+            with mock.patch("beacon_skill.storage.fcntl") as fcntl_mock:
+                with state_lock(write=True):
+                    append_jsonl("events.jsonl", {"kind": "ok"})
+
+                fcntl_mock.flock.assert_not_called()
+        self.assertTrue((Path(self.tmpdir) / "state.json.lock").exists())
+        self.assertEqual(read_jsonl("events.jsonl"), [{"kind": "ok"}])
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Description
Adds regression coverage for the non-POSIX storage lock fallback used when fcntl is unavailable. This keeps the Windows path from #869 covered; the current main branch already has the fallback implementation.

## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update

## Testing
- [x] python -m unittest tests.test_storage
- [x] Windows import check for beacon_skill and beacon_skill.storage
- [x] git diff --check (only LF-to-CRLF warning from Git on Windows)

## Checklist
- [x] My code follows the style guidelines
- [x] I have performed a self-review
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have tested changes locally

## Bounty Claim
If this PR addresses a bounty issue:
- Issue number: #869
- Wallet ID: to be provided if required