### PR TITLE
ci: smoke-test built package on Windows

### DIFF
--- a/.github/workflows/package-smoke.yml
+++ b/.github/workflows/package-smoke.yml
@@ -1,0 +1,39 @@
+name: Package Smoke
+
+on:
+  pull_request:
+  push:
+    branches:
+      - main
+
+jobs:
+  smoke:
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        os:
+          - ubuntu-latest
+          - windows-latest
+
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+
+      - name: Build wheel and sdist
+        run: |
+          python -m pip install --upgrade pip build
+          python -m build
+
+      - name: Install built wheel
+        run: python -m pip install --force-reinstall dist/*.whl
+
+      - name: Smoke-test installed package
+        run: |
+          python -c "import beacon_skill; print(beacon_skill.__version__)"
+          beacon --help

--- a/.github/workflows/package-smoke.yml
+++ b/.github/workflows/package-smoke.yml
@@ -31,7 +31,10 @@ jobs:
           python -m build
 
       - name: Install built wheel
-        run: python -m pip install --force-reinstall dist/*.whl
+        run: >
+          python -c "import glob, subprocess, sys; wheels = glob.glob('dist/*.whl');
+          assert len(wheels) == 1, wheels;
+          subprocess.check_call([sys.executable, '-m', 'pip', 'install', '--force-reinstall', wheels[0]])"
 
       - name: Smoke-test installed package
         run: |


### PR DESCRIPTION
## Summary
- add a package smoke-test workflow that builds the distribution on each PR/push
- install the built wheel on both Windows and Linux runners instead of importing from the source tree
- verify both `import beacon_skill` and `beacon --help` so release regressions like the broken Windows PyPI package are caught before publish

## Testing
- `python -m build`
- `python -m venv work\\beacon-skill-smoke-venv`
- `work\\beacon-skill-smoke-venv\\Scripts\\python -m pip install --force-reinstall work\\beacon-skill\\dist\\beacon_skill-2.16.0-py3-none-any.whl`
- `work\\beacon-skill-smoke-venv\\Scripts\\python -c "import beacon_skill; print(beacon_skill.__version__)"`
- `work\\beacon-skill-smoke-venv\\Scripts\\beacon.exe --help`

Fixes #868.

Wallet ID: github:dallasnetprofu02-design
