### PR TITLE
Add minimum Beacon envelope reference

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@ Beacon is an agent-to-agent protocol for **social coordination**, **crypto payme
 **Signed envelopes**: Ed25519 identity, TOFU key learning, replay protection
 **Security guide**: [docs/SECURITY.md](docs/SECURITY.md) - Nonce strategy, timestamp validation, idempotency patterns
 **Mechanism spec**: docs/BEACON_MECHANISM_TEST.md
+**Interop doc**: [docs/MINIMUM_ENVELOPE.md](docs/MINIMUM_ENVELOPE.md) - Required fields, canonical signing rules, replay window, failure reasons
 **Agent discovery**: `.well-known/beacon.json` agent cards
 
 ## Quick Start (2 minutes)
@@ -137,6 +138,8 @@ All messages are wrapped in signed envelopes:
 ```
 
 v1 envelopes (`[BEACON v1]`) are still parsed for backward compatibility but lack signatures and agent identity.
+
+For implementers building a Beacon sender/receiver in another language, see [`docs/MINIMUM_ENVELOPE.md`](docs/MINIMUM_ENVELOPE.md) for the minimum interoperable envelope contract.
 
 ## Transports
 

--- a/docs/MINIMUM_ENVELOPE.md
+++ b/docs/MINIMUM_ENVELOPE.md
@@ -1,0 +1,144 @@
+# Beacon minimum interoperable envelope
+
+This page is the compact implementation-facing reference for Beacon v2 signed envelopes. It is meant for authors building a Beacon receiver, sender, or verifier in another language without reverse-engineering the Python package.
+
+The normative implementation is still the code in `beacon_skill.codec`, `beacon_skill.guard`, and the webhook transports. This document summarizes the minimum shape and validation behavior they currently enforce.
+
+## Minimal valid v2 envelope
+
+```json
+{
+  "v": 2,
+  "kind": "hello",
+  "agent_id": "bcn_a1b2c3d4e5f6",
+  "ts": 1735689600,
+  "nonce": "f7a3b2c1d4e5",
+  "pubkey": "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef",
+  "sig": "<ed25519_hex_signature>"
+}
+```
+
+Beacon frames that payload as:
+
+```text
+[BEACON v2]
+{"agent_id":"bcn_a1b2c3d4e5f6","kind":"hello","nonce":"f7a3b2c1d4e5","pubkey":"0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef","sig":"<ed25519_hex_signature>","ts":1735689600,"v":2}
+```
+
+For new integrations, prefer v2 only. Beacon still parses v1 envelopes for backward compatibility, but v1 lacks signed identity.
+
+## Required fields and types
+
+| Field | Required | Type | Notes |
+|---|---:|---|---|
+| `v` | yes | integer | Protocol version. For interoperable signed envelopes, use `2`. |
+| `kind` | yes | string | Message kind such as `hello`, `want`, `bounty`, `heartbeat`, etc. The codec is kind-agnostic. |
+| `agent_id` | yes | string | Sender identity in the form `bcn_` plus 12 lowercase hex characters derived from the Ed25519 public key. |
+| `ts` | yes | integer | Unix timestamp in seconds. Used for freshness checks. |
+| `nonce` | yes | string | Single-use nonce. Beacon's default generator emits 12 lowercase hex chars. |
+| `sig` | yes | string | Ed25519 signature in hex over the canonical JSON payload without `sig`. |
+| `pubkey` | recommended | string | Hex-encoded Ed25519 public key. Required unless the receiver already has a trusted key for `agent_id`. |
+
+Additional application payload fields such as `text`, `to`, `from`, `reward_rtc`, `topics`, or feature-specific fields may be included and are covered by the signature.
+
+## What exactly gets signed
+
+Beacon signs the full envelope payload except `sig`.
+
+Rules:
+
+- Remove the `sig` field before signing or verifying.
+- Keep every other field exactly as transmitted.
+- Serialize with JSON object keys sorted lexicographically.
+- Use compact separators: `,` between items and `:` between key/value pairs.
+- Encode as UTF-8 bytes before Ed25519 signing.
+
+Python reference equivalent:
+
+```python
+json.dumps(payload_without_sig, sort_keys=True, separators=(",", ":")).encode("utf-8")
+```
+
+This means application fields are part of the signature, not just the protocol metadata.
+
+## Verification rules
+
+A receiver that matches Beacon's current behavior should:
+
+1. Extract the JSON body from a `[BEACON v2]` frame.
+2. Read `sig`.
+3. Obtain the public key from `pubkey` or a trusted key cache keyed by `agent_id`.
+4. Recompute the expected `agent_id` from the public key and compare it to the claimed `agent_id`.
+5. Verify the Ed25519 signature over the canonical JSON payload without `sig`.
+6. Check timestamp freshness and replay protection.
+
+If the receiver cannot obtain a public key, verification is not possible and Beacon treats the envelope as `signature_unverifiable`.
+
+## Freshness and replay window
+
+Beacon's current guard defaults are:
+
+- maximum age: `900` seconds
+- maximum future skew: `120` seconds
+- nonce cache size: `50000`
+
+An envelope is rejected if:
+
+- `nonce` is missing
+- `ts` is missing or not parseable as an integer
+- `ts` is older than 15 minutes
+- `ts` is more than 2 minutes in the future
+- `nonce` was already seen in the replay cache
+
+The replay cache stores nonce-to-timestamp entries and prunes old entries before checking the new envelope.
+
+## Receiver result codes
+
+These are the main reasons surfaced by the current webhook receivers:
+
+| Reason | Meaning |
+|---|---|
+| `ok` | Signature verified and freshness/replay checks passed. |
+| `signature_invalid` | A public key was available, but the signature or claimed `agent_id` did not match. |
+| `signature_unverifiable` | No public key was available, so the receiver could not verify the envelope. |
+| `missing_nonce` | `nonce` is absent or empty. |
+| `missing_ts` | `ts` is absent or not an integer. |
+| `stale_ts` | Timestamp is older than the allowed age window. |
+| `future_ts` | Timestamp is too far in the future. |
+| `replay_nonce` | `nonce` already exists in the replay cache. |
+
+Webhook-level wrappers may also report aggregate errors such as `no_beacon_envelopes_found` or `no_valid_envelopes` when the request body contains no acceptable envelope.
+
+## Unknown senders and unsupported kinds
+
+Two important implementation notes:
+
+- Unknown sender: if the receiver has neither an embedded `pubkey` nor a trusted key for `agent_id`, Beacon does not accept the envelope on trust alone. It reports `signature_unverifiable`.
+- Unsupported kind: Beacon's codec does not reject unknown `kind` values at the envelope layer. Transport or application policy may reject them later, but that is outside the minimum envelope contract.
+
+## Sender checklist
+
+For a minimally interoperable sender:
+
+1. Set `v` to `2`.
+2. Include `kind`, `agent_id`, `ts`, and `nonce`.
+3. Include `pubkey` unless you know the receiver has already pinned your key.
+4. Sign the canonical JSON payload without `sig`.
+5. Emit the result inside a `[BEACON v2]` frame or send the JSON body directly to a receiver that already expects decoded Beacon JSON.
+
+## Cross-language checklist
+
+If you are implementing Beacon in another language, test at least these cases:
+
+1. Valid signed envelope with embedded `pubkey` is accepted once.
+2. Sending the identical envelope twice returns `replay_nonce` on the second attempt.
+3. Tampering with any signed field returns `signature_invalid`.
+4. Omitting `pubkey` for an unknown sender returns `signature_unverifiable`.
+5. Old timestamps return `stale_ts`.
+6. Future timestamps return `future_ts`.
+
+## Related docs
+
+- `docs/SECURITY.md` for replay protection and idempotency guidance
+- `docs/BEACON_MECHANISM_TEST.md` for mechanism-level invariants and falsification tests
+- `docs/AGENT_CARD.md` for `/.well-known/beacon.json` discovery cards

--- a/tests/test_minimum_envelope_doc.py
+++ b/tests/test_minimum_envelope_doc.py
@@ -1,0 +1,44 @@
+import json
+import re
+from pathlib import Path
+
+
+def test_minimum_envelope_doc_has_minimal_example_and_receiver_rules() -> None:
+    text = Path("docs/MINIMUM_ENVELOPE.md").read_text()
+
+    assert "## Minimal valid v2 envelope" in text
+    assert "## Required fields and types" in text
+    assert "## What exactly gets signed" in text
+    assert "## Verification rules" in text
+    assert "## Receiver result codes" in text
+    assert "## Cross-language checklist" in text
+    assert "docs/SECURITY.md" in text
+    assert "docs/BEACON_MECHANISM_TEST.md" in text
+
+    match = re.search(r"```json\n(.*?)\n```", text, re.S)
+    assert match is not None
+    envelope = json.loads(match.group(1))
+    assert set(envelope) == {"v", "kind", "agent_id", "ts", "nonce", "pubkey", "sig"}
+    assert envelope["v"] == 2
+    assert envelope["kind"] == "hello"
+
+    for field in ("v", "kind", "agent_id", "ts", "nonce", "sig"):
+        assert f"| `{field}` | yes |" in text
+    assert "| `pubkey` | recommended |" in text
+
+    for reason in (
+        "ok",
+        "signature_invalid",
+        "signature_unverifiable",
+        "missing_nonce",
+        "missing_ts",
+        "stale_ts",
+        "future_ts",
+        "replay_nonce",
+    ):
+        assert f"| `{reason}` |" in text
+
+    assert "sort_keys=True" in text
+    assert 'separators=(",", ":")' in text
+    assert "maximum age: `900` seconds" in text
+    assert "maximum future skew: `120` seconds" in text


### PR DESCRIPTION
## Summary
- add a compact `docs/MINIMUM_ENVELOPE.md` reference for Beacon v2 envelopes
- document required fields, canonical signing rules, replay/freshness windows, and receiver result codes from the current implementation
- add a docs test to keep the minimal envelope example aligned with the implementation-facing contract

Fixes #867.

## Validation
- `python -m pytest tests/test_minimum_envelope_doc.py -q`
- `git diff --check`