### PR TITLE
fix: sync version metadata with 2.16.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Beacon 2.16.0 (beacon-skill)
+# Beacon 2.16.1 (beacon-skill)
 
 [![Watch: Introducing Beacon Protocol](https://bottube.ai/badge/seen-on-bottube.svg)](https://bottube.ai/watch/CWa-DLDptQA)
 [![Featured on ToolPilot.ai](https://www.toolpilot.ai/cdn/shop/files/toolpilot-badge-w.png)](https://www.toolpilot.ai)

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "beacon-skill",
-  "version": "2.16.0",
+  "version": "2.16.1",
   "description": "Beacon - the AI agent orchestrator. 13 transports, agent scorecard dashboard, heartbeat, mayday, accords, virtual cities, proof-of-thought, relay, memory markets, hybrid districts, x402 micropayments, compute marketplace",
   "bin": {
     "beacon": "bin/beacon.js"
@@ -79,6 +79,6 @@
     ],
     "author": "Elyan Labs",
     "homepage": "https://bottube.ai/skills/beacon",
-    "version": "2.16.0"
+    "version": "2.16.1"
   }
 }


### PR DESCRIPTION
## Summary
- update the root npm package version to `2.16.1`
- update the nested `claudeSkill.version` metadata to `2.16.1`
- update the README heading to show the current release

## Why
The Python package and changelog already identify `2.16.1` as the current Windows install-fix release, while npm-facing metadata and the README still reported `2.16.0`.

## Validation
- parsed `package.json` successfully
- verified version parity across `package.json`, `claudeSkill.version`, `pyproject.toml`, `beacon_skill.__version__`, and the README heading
- `git diff --check`

Fixes #884