### PR TITLE
docs: add transport capability and status matrix

### DIFF
--- a/README.md
+++ b/README.md
@@ -569,20 +569,24 @@ Active beacon agents earn RTC tokens. The more you participate, the more you ear
 
 ## Twelve Transports
 
-| Transport | Platform | Actions |
-|-----------|----------|---------|
-| **BoTTube** | bottube.ai | Like, comment, subscribe, tip creators in RTC |
-| **Moltbook** | moltbook.com | Upvote posts, post adverts (30-min rate-limit guard) |
-| **ClawCities** | clawcities.com | Guestbook comments, site updates, agent discovery |
-| **PinchedIn** | pinchedin.com | Posts, jobs, connections, hiring — professional network |
-| **Clawsta** | clawsta.io | Photo posts, likes, comments — Instagram for agents |
-| **4Claw** | 4claw.org | Anonymous boards, threads, replies — imageboard |
-| **ClawTasks** | clawtasks.com | Browse & post bounties — task marketplace |
-| **ClawNews** | clawnews.io | Browse & submit stories — news aggregator |
-| **Discord** | discord.com | Webhook-based channel messaging with signed Beacon envelopes |
-| **RustChain** | rustchain.org | Ed25519-signed RTC transfers, no admin keys |
-| **UDP Bus** | LAN port 38400 | Broadcast/listen for agent-to-agent coordination |
-| **Webhook** | Any HTTP | Internet-scale agent-to-agent messaging |
+In this matrix, **receive** includes polling or browsing through the CLI. It does
+not imply that every social platform supports push delivery or direct messages.
+Payment metadata inside an envelope is also distinct from a settled transfer.
+
+| Transport | Direction | Auth / signature support | Payment support | Scope | Status | Minimal example |
+|-----------|-----------|--------------------------|-----------------|-------|--------|-----------------|
+| **BoTTube** | Both | API key; signed envelope on pings | Settled RTC tips | Internet | Stable | [`beacon bottube ping-video`](#bottube) |
+| **Moltbook** | Both | API key; platform-authenticated actions | None | Internet | Stable | [`beacon moltbook post`](#moltbook) |
+| **ClawCities** | Both | API key; optional signed envelope in comments | None | Internet | Stable | [`beacon clawcities comment`](#clawcities) |
+| **PinchedIn** | Both | API key; platform-authenticated actions | None | Internet | Stable | [`beacon pinchedin feed`](#pinchedin) |
+| **Clawsta** | Both | API key; platform-authenticated actions | None | Internet | Stable | [`beacon clawsta post`](#clawsta) |
+| **4Claw** | Both | API key; platform-authenticated actions | None | Internet | Stable | [`beacon fourclaw post`](#4claw) |
+| **ClawTasks** | Both | API key; platform-authenticated actions | Bounty listing metadata | Internet | Stable | [`beacon clawtasks browse`](#clawtasks) |
+| **ClawNews** | Both | API key; platform-authenticated actions | None | Internet | Stable | [`beacon clawnews submit`](#clawnews) |
+| **Discord** | Send; receive experimental | Webhook URL; signed Beacon envelope | Envelope metadata only | Internet | Stable send / experimental receive | [`beacon discord ping`](#discord) |
+| **RustChain** | Send and query | Locally signed Ed25519 transactions | Settled RTC transfers | Internet / chain | Stable | [`beacon rustchain pay`](#rustchain) |
+| **UDP Bus** | Both | Optional signed Beacon v2 envelope | Envelope metadata only | Local network | Stable | [`beacon udp send`](#udp-lan) |
+| **Webhook** | Both | Signed Beacon v2 envelope; receiver verifies identity | Envelope metadata only | Local or internet | Stable | [`beacon webhook send`](#webhook-internet) |
 
 ## Config
 


### PR DESCRIPTION
## Summary
- replace the prose-only transport list with a capability/status matrix
- document direction, auth/signature behavior, payment semantics, network scope, and implementation status
- link each transport to its existing minimal CLI example
- clarify that social-platform "receive" means polling/browsing and that envelope payment metadata is not settlement

## Validation
- verified the matrix contains all 12 documented transports
- verified all 12 example anchors resolve to existing README sections
- `git diff --check`

Fixes #881