### PR TITLE
feat: surface relay token expiry and refresh guidance

### DIFF
--- a/beacon_skill/cli.py
+++ b/beacon_skill/cli.py
@@ -4179,6 +4179,17 @@ def cmd_relay_heartbeat(args: argparse.Namespace) -> int:
     return 0
 
 
+def cmd_relay_status(args: argparse.Namespace) -> int:
+    from .relay import RelayManager
+    identity = _load_identity(args)
+    mgr = RelayManager(host_identity=identity)
+    agent_id = getattr(args, "agent_id", None)
+    refresh_window = int(getattr(args, "refresh_window", 3600))
+    result = mgr.token_status(agent_id, refresh_window_s=refresh_window)
+    print(json.dumps(result, indent=2, default=str))
+    return 1 if result.get("error") else 0
+
+
 def cmd_relay_get(args: argparse.Namespace) -> int:
     from .relay import RelayManager
     mgr = RelayManager()
@@ -5770,6 +5781,17 @@ def main(argv: Optional[List[str]] = None) -> None:
     sp.add_argument("--token", required=True, help="Authentication token")
     sp.add_argument("--status", default="alive", help="Status: alive, busy, draining")
     sp.set_defaults(func=cmd_relay_heartbeat)
+
+    sp = relay_sub.add_parser("status", help="Show relay token expiry and Atlas refresh guidance")
+    sp.add_argument("agent_id", nargs="?", default=None, help="Agent ID (omit for own or sole relay)")
+    sp.add_argument(
+        "--refresh-window",
+        type=int,
+        default=3600,
+        help="Warn when token expires within this many seconds (default: 3600)",
+    )
+    sp.add_argument("--password", default=None, help="Password for encrypted identity")
+    sp.set_defaults(func=cmd_relay_status)
 
     sp = relay_sub.add_parser("get", help="Get details for a relay agent")
     sp.add_argument("agent_id", help="Agent ID to look up")

--- a/beacon_skill/relay.py
+++ b/beacon_skill/relay.py
@@ -15,6 +15,7 @@ import hashlib
 import json
 import secrets
 import time
+from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any, Dict, List, Optional
 
@@ -26,6 +27,8 @@ RELAY_LOG_FILE = "relay_log.jsonl"
 
 # Relay token TTL: 24 hours
 RELAY_TOKEN_TTL_S = 86400
+# Warn while there is still enough time to send a heartbeat and refresh the TTL.
+RELAY_TOKEN_REFRESH_WARNING_S = 3600
 # Heartbeat timeout: 15 minutes of silence = inactive
 RELAY_SILENCE_THRESHOLD_S = 900
 # 1 hour = presumed dead
@@ -374,6 +377,111 @@ class RelayManager:
         data["status"] = assessed_status
         agent.status = assessed_status
         return agent.to_public_dict()
+
+    def token_status(
+        self,
+        agent_id: Optional[str] = None,
+        *,
+        refresh_window_s: int = RELAY_TOKEN_REFRESH_WARNING_S,
+    ) -> Dict[str, Any]:
+        """Return operator-safe relay credential and Atlas status.
+
+        The relay token itself is intentionally never returned. If no agent ID
+        is supplied, the host identity is preferred, followed by the sole local
+        relay registration when only one exists.
+        """
+        agents = self._load_agents()
+        selected_id = agent_id
+
+        if not selected_id and self._host_identity:
+            host_agent_id = getattr(self._host_identity, "agent_id", "")
+            if host_agent_id in agents:
+                selected_id = host_agent_id
+
+        if not selected_id and len(agents) == 1:
+            selected_id = next(iter(agents))
+
+        if not selected_id:
+            if not agents:
+                return {
+                    "error": "No relay registration found",
+                    "code": "NOT_REGISTERED",
+                    "active": False,
+                    "expires_at": None,
+                    "atlas_status": "unregistered",
+                    "next_action": (
+                        "beacon relay register --pubkey <pubkey> "
+                        "--model-id <model-id> --name <unique-name>"
+                    ),
+                }
+            return {
+                "error": "Multiple relay registrations found; specify agent_id",
+                "code": "AGENT_ID_REQUIRED",
+                "available_agents": sorted(agents),
+                "next_action": "beacon relay status <agent-id>",
+            }
+
+        data = agents.get(selected_id)
+        if not data:
+            return {
+                "error": "Agent not registered",
+                "code": "NOT_FOUND",
+                "agent_id": selected_id,
+                "active": False,
+                "expires_at": None,
+                "atlas_status": "unregistered",
+                "next_action": (
+                    "beacon relay register --pubkey <pubkey> "
+                    "--model-id <model-id> --name <unique-name>"
+                ),
+            }
+
+        now = int(time.time())
+        try:
+            expires_at = int(data.get("token_expires", 0))
+        except (TypeError, ValueError):
+            expires_at = 0
+        seconds_remaining = max(0, expires_at - now)
+        active = expires_at > now
+        atlas_status = RelayAgent(data).assess_status()
+
+        expiry_iso = None
+        if expires_at > 0:
+            expiry_iso = (
+                datetime.fromtimestamp(expires_at, tz=timezone.utc)
+                .isoformat()
+                .replace("+00:00", "Z")
+            )
+
+        heartbeat_command = (
+            f"beacon relay heartbeat --agent-id {selected_id} "
+            "--token <relay-token> --status alive"
+        )
+        if not active:
+            name = json.dumps(str(data.get("name") or "<unique-name>"))
+            next_action = (
+                "beacon relay register "
+                f"--pubkey {data.get('pubkey_hex') or '<pubkey>'} "
+                f"--model-id {data.get('model_id') or '<model-id>'} "
+                f"--provider {data.get('provider') or 'other'} "
+                f"--name {name}"
+            )
+        elif seconds_remaining <= max(0, int(refresh_window_s)):
+            next_action = heartbeat_command
+        elif atlas_status != "active":
+            next_action = heartbeat_command
+        else:
+            next_action = "none"
+
+        return {
+            "agent_id": selected_id,
+            "active": active,
+            "expires_at": expiry_iso,
+            "expires_at_epoch": expires_at,
+            "seconds_remaining": seconds_remaining,
+            "atlas_status": atlas_status,
+            "next_action": next_action,
+        }
 
     # ── Message Forwarding ──
 

--- a/tests/test_relay_token_status.py
+++ b/tests/test_relay_token_status.py
@@ -1,0 +1,96 @@
+import json
+import tempfile
+import unittest
+from pathlib import Path
+from unittest.mock import patch
+
+from beacon_skill.relay import RELAY_STATE_FILE, RelayManager
+
+
+class TestRelayTokenStatus(unittest.TestCase):
+    def setUp(self) -> None:
+        self._tmp = tempfile.TemporaryDirectory()
+        self.data_dir = Path(self._tmp.name)
+        self.manager = RelayManager(data_dir=self.data_dir)
+
+    def tearDown(self) -> None:
+        self._tmp.cleanup()
+
+    def _register(self, now: int = 1000):
+        with patch("beacon_skill.relay.time.time", return_value=now):
+            return self.manager.register(
+                pubkey_hex="12" * 32,
+                model_id="demo-model",
+                provider="other",
+                name="North Star",
+            )
+
+    def _set_expiry(self, agent_id: str, expires_at: int) -> None:
+        state_path = self.data_dir / RELAY_STATE_FILE
+        agents = json.loads(state_path.read_text(encoding="utf-8"))
+        agents[agent_id]["token_expires"] = expires_at
+        state_path.write_text(json.dumps(agents), encoding="utf-8")
+
+    def test_active_status_reports_expiry_without_exposing_token(self) -> None:
+        registered = self._register()
+        with patch("beacon_skill.relay.time.time", return_value=1500):
+            result = self.manager.token_status(
+                registered["agent_id"],
+                refresh_window_s=60,
+            )
+
+        self.assertTrue(result["active"])
+        self.assertEqual("active", result["atlas_status"])
+        self.assertEqual("none", result["next_action"])
+        self.assertEqual("1970-01-02T00:16:40Z", result["expires_at"])
+        self.assertNotIn("relay_token", result)
+        self.assertNotIn(registered["relay_token"], json.dumps(result))
+
+    def test_near_expiry_recommends_heartbeat_with_placeholder(self) -> None:
+        registered = self._register()
+        self._set_expiry(registered["agent_id"], 2500)
+
+        with patch("beacon_skill.relay.time.time", return_value=2000):
+            result = self.manager.token_status(
+                registered["agent_id"],
+                refresh_window_s=600,
+            )
+
+        self.assertTrue(result["active"])
+        self.assertEqual(500, result["seconds_remaining"])
+        self.assertIn("beacon relay heartbeat", result["next_action"])
+        self.assertIn("<relay-token>", result["next_action"])
+        self.assertNotIn(registered["relay_token"], json.dumps(result))
+
+    def test_expired_status_recommends_registration(self) -> None:
+        registered = self._register()
+        self._set_expiry(registered["agent_id"], 1500)
+
+        with patch("beacon_skill.relay.time.time", return_value=2000):
+            result = self.manager.token_status(registered["agent_id"])
+
+        self.assertFalse(result["active"])
+        self.assertEqual(0, result["seconds_remaining"])
+        self.assertIn("beacon relay register", result["next_action"])
+        self.assertIn("--name \"North Star\"", result["next_action"])
+        self.assertNotIn(registered["relay_token"], json.dumps(result))
+
+    def test_sole_registration_is_selected_without_agent_id(self) -> None:
+        registered = self._register()
+
+        with patch("beacon_skill.relay.time.time", return_value=2000):
+            result = self.manager.token_status()
+
+        self.assertEqual(registered["agent_id"], result["agent_id"])
+
+    def test_empty_state_returns_registration_guidance(self) -> None:
+        result = self.manager.token_status()
+
+        self.assertEqual("NOT_REGISTERED", result["code"])
+        self.assertFalse(result["active"])
+        self.assertEqual("unregistered", result["atlas_status"])
+        self.assertIn("beacon relay register", result["next_action"])
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

- add `beacon relay status [agent_id]` for operator-safe relay credential checks
- report `active`, UTC `expires_at`, `atlas_status`, remaining lifetime, and `next_action`
- recommend heartbeat refreshes for stale/near-expiry registrations and re-registration after expiry
- never return or interpolate the stored relay token; guidance uses `<relay-token>` placeholders
- select the current identity or sole local relay automatically when possible

## Validation

- `python -m unittest tests.test_relay_token_status tests.test_relay_status_assessment tests.test_relay_heartbeat_and_registration -v` (9 passed)
- `python -m compileall -q beacon_skill tests/test_relay_token_status.py`
- exercised `python -m beacon_skill.cli relay status <agent_id>` against an isolated temporary relay registration

The broader local discovery run reached 420 tests but could not complete because the existing venv lacks development dependencies including `pytest`, `flask`, and `fastapi`; its reported ClawNews failures are unrelated to this change.

Closes #883