### PR TITLE
fix: retire legacy beacon join route

### DIFF
--- a/atlas/beacon_chat.py
+++ b/atlas/beacon_chat.py
@@ -1156,7 +1156,7 @@ def relay_heartbeat():
         # and receive a valid relay_token.
         return cors_json({
             "error": "Unknown agent — register first via /relay/register",
-            "code": "AGENT_NOT_FOUND"
+            "code": "AGENT_NOT_REGISTERED"
 
         }, 404)
 
@@ -1760,69 +1760,6 @@ def api_all_agents():
     # Native agents from AGENT_PERSONAS
     # ... code continues untouched ...
     
-@app.route("/beacon/join", methods=["POST", "OPTIONS"])
-def api_beacon_join():
-    """Register a new external agent via the beacon network."""
-    if request.method == "OPTIONS":
-        resp = jsonify({})
-        resp.headers["Access-Control-Allow-Origin"] = "*"
-        resp.headers["Access-Control-Allow-Methods"] = "POST"
-        resp.headers["Access-Control-Allow-Headers"] = "Content-Type"
-        return resp, 204
-
-    data = request.json or {}
-    
-    agent_id = data.get("agent_id")
-    pubkey_hex = data.get("pubkey_hex")
-    
-    if not agent_id or not pubkey_hex:
-        return cors_json({"error": "Missing agent_id or pubkey_hex"}, 400)
-        
-    if len(pubkey_hex) != 64 or not all(c in "0123456789abcdefABCDEF" for c in pubkey_hex):
-        return cors_json({"error": "Invalid pubkey_hex format"}, 400)
-        
-    persona = data.get("persona", "Unknown relay agent")
-    provider = data.get("provider", "External")
-    capabilities = data.get("capabilities", [])
-    
-    # Save to SQLite
-    try:
-        conn = sqlite3.connect(ATLAS_DB_PATH)
-        c = conn.cursor()
-        c.execute("""
-            INSERT INTO relay_agents (agent_id, pubkey_hex, persona, provider, created_at, last_seen)
-            VALUES (?, ?, ?, ?, ?, ?)
-            ON CONFLICT(agent_id) DO UPDATE SET
-                pubkey_hex=excluded.pubkey_hex,
-                persona=excluded.persona,
-                provider=excluded.provider,
-                last_seen=excluded.last_seen
-        """, (
-            agent_id, 
-            pubkey_hex, 
-            persona, 
-            provider, 
-            int(time.time()), 
-            int(time.time())
-        ))
-        
-        # Clear old capabilities and insert new ones
-        c.execute("DELETE FROM relay_agent_capabilities WHERE agent_id=?", (agent_id,))
-        for cap in capabilities:
-            if cap and isinstance(cap, str):
-                c.execute("INSERT INTO relay_agent_capabilities (agent_id, capability) VALUES (?, ?)", (agent_id, cap[:100]))
-                
-        conn.commit()
-        conn.close()
-    except Exception as e:
-        app.logger.error(f"Error registering agent {agent_id}: {e}")
-        return cors_json({"error": "Database error"}, 500)
-
-    return cors_json({
-        "status": "registered",
-        "agent_id": agent_id,
-        "tier": "agent"
-    }, 201)
     agents = []
     for aid, persona in AGENT_PERSONAS.items():
         agents.append({

--- a/tests/test_beacon_join_retired.py
+++ b/tests/test_beacon_join_retired.py
@@ -1,0 +1,40 @@
+import sys
+from pathlib import Path
+
+import pytest
+
+
+ATLAS_DIR = Path(__file__).resolve().parents[1] / "atlas"
+if str(ATLAS_DIR) not in sys.path:
+    sys.path.insert(0, str(ATLAS_DIR))
+
+import beacon_chat
+
+
+@pytest.fixture()
+def client(monkeypatch, tmp_path):
+    db_path = tmp_path / "beacon_join_retired.db"
+    monkeypatch.setattr(beacon_chat, "DB_PATH", str(db_path), raising=False)
+    beacon_chat.ATLAS_RATE_LIMITER._entries.clear()
+    beacon_chat.ATLAS_RATE_LIMITER._last_cleanup = 0
+    beacon_chat.init_db()
+    beacon_chat.app.config["TESTING"] = True
+    yield beacon_chat.app.test_client()
+
+
+def test_legacy_beacon_join_route_is_retired(client):
+    response = client.post(
+        "/beacon/join",
+        json={"agent_id": "bcn_attacker001", "pubkey_hex": "11" * 32},
+    )
+
+    assert response.status_code == 404
+
+
+def test_api_agents_returns_native_agents_after_route_removal(client):
+    response = client.get("/api/agents")
+
+    assert response.status_code == 200
+    agents = response.get_json()
+    native_agent_ids = {agent["agent_id"] for agent in agents if not agent["relay"]}
+    assert "bcn_sophia_elya" in native_agent_ids


### PR DESCRIPTION
## Summary
- remove the superseded `/beacon/join` route called out in #862 H3
- restore the remaining `/api/agents` native/relay listing code path that had been stranded after the legacy route
- align the unknown heartbeat error code with the existing security regression test

## Tests
- python -m pytest tests/test_beacon_join_retired.py tests/test_relay_heartbeat_security.py tests/test_relay_register_security.py tests/test_relay_seo_security.py -q
- python -m py_compile atlas/beacon_chat.py tests/test_beacon_join_retired.py

Refs #862