### PR TITLE
fix: require relay register signatures

### DIFF
--- a/atlas/beacon_chat.py
+++ b/atlas/beacon_chat.py
@@ -958,7 +958,7 @@ def relay_register():
         capabilities: List of domains (e.g. ["coding", "research", "creative"])
         webhook_url: Optional callback URL
         name: Human-readable name
-        signature: Optional Ed25519 signature for verification
+        signature: Ed25519 signature proving ownership of pubkey_hex
 
     Returns:
         agent_id, relay_token, token_expires, ttl_s
@@ -1025,23 +1025,23 @@ def relay_register():
     if not isinstance(capabilities, list):
         return cors_json({"error": "capabilities must be a list"}, 400)
 
-    # Verify signature if provided and nacl is available
-    sig_verified = None
-    if signature:
-        reg_payload = json.dumps({
-            "model_id": model_id,
-            "provider": provider,
-            "pubkey_hex": pubkey_hex,
-        }, sort_keys=True, separators=(",", ":")).encode("utf-8")
-        sig_verified = verify_ed25519(pubkey_hex, signature, reg_payload)
-        if sig_verified is None:
-            app.logger.error("NaCl unavailable, rejecting signed registration for pubkey %s", pubkey_hex[:16])
-            return cors_json({
-                "error": "Signature verification unavailable",
-                "hint": "Server missing Ed25519 verification support (PyNaCl)"
-            }, 503)
-        if sig_verified is False:
-            return cors_json({"error": "Invalid Ed25519 signature"}, 403)
+    if not signature:
+        return cors_json({"error": "signature required for relay registration"}, 400)
+
+    reg_payload = json.dumps({
+        "model_id": model_id,
+        "provider": provider,
+        "pubkey_hex": pubkey_hex,
+    }, sort_keys=True, separators=(",", ":")).encode("utf-8")
+    sig_verified = verify_ed25519(pubkey_hex, signature, reg_payload)
+    if sig_verified is None:
+        app.logger.error("NaCl unavailable, rejecting signed registration for pubkey %s", pubkey_hex[:16])
+        return cors_json({
+            "error": "Signature verification unavailable",
+            "hint": "Server missing Ed25519 verification support (PyNaCl)"
+        }, 503)
+    if sig_verified is False:
+        return cors_json({"error": "Invalid Ed25519 signature"}, 403)
 
     # Derive agent_id
     agent_id = agent_id_from_pubkey_hex(pubkey_hex)

--- a/tests/test_collaborator_matcher.py
+++ b/tests/test_collaborator_matcher.py
@@ -57,7 +57,9 @@ def _insert_relay_agent(agent_id, *, name, capabilities=None, metadata=None, pro
         db.commit()
 
 
-def test_relay_register_persists_collaboration_metadata(client):
+def test_relay_register_persists_collaboration_metadata(client, monkeypatch):
+    monkeypatch.setattr(beacon_chat, "verify_ed25519", lambda *_args, **_kwargs: True)
+
     resp = client.post(
         "/relay/register",
         json={
@@ -72,6 +74,7 @@ def test_relay_register_persists_collaboration_metadata(client):
             "curiosities": ["PowerPC"],
             "preferred_city": "New Orleans",
             "values_hash": "abc123",
+            "signature": "aa" * 64,
         },
     )
     assert resp.status_code == 201

--- a/tests/test_relay_register_security.py
+++ b/tests/test_relay_register_security.py
@@ -1,5 +1,6 @@
 import sqlite3
 import sys
+import json
 from pathlib import Path
 
 import pytest
@@ -11,6 +12,11 @@ if str(ATLAS_DIR) not in sys.path:
 
 import beacon_chat
 
+try:
+    from nacl.signing import SigningKey
+except Exception:  # pragma: no cover - optional dependency in CI
+    SigningKey = None
+
 
 def _registration_payload():
     return {
@@ -21,6 +27,29 @@ def _registration_payload():
         "name": "relay-security-test",
         "signature": "22" * 64,
     }
+
+
+def _signed_registration_payload():
+    signing_key = SigningKey.generate()
+    pubkey_hex = signing_key.verify_key.encode().hex()
+    payload = {
+        "pubkey_hex": pubkey_hex,
+        "model_id": "grok-test",
+        "provider": "xai",
+        "capabilities": ["coding"],
+        "name": "relay-security-test",
+    }
+    signed = json.dumps(
+        {
+            "model_id": payload["model_id"],
+            "provider": payload["provider"],
+            "pubkey_hex": payload["pubkey_hex"],
+        },
+        sort_keys=True,
+        separators=(",", ":"),
+    ).encode("utf-8")
+    payload["signature"] = signing_key.sign(signed).signature.hex()
+    return payload
 
 
 @pytest.fixture()
@@ -51,6 +80,49 @@ def test_relay_register_fails_closed_when_crypto_unavailable(client, monkeypatch
     assert body and "verification unavailable" in body.get("error", "").lower()
 
     # Ensure registration was not written to DB.
+    conn = sqlite3.connect(beacon_chat.DB_PATH)
+    try:
+        count = conn.execute("SELECT COUNT(*) FROM relay_agents").fetchone()[0]
+    finally:
+        conn.close()
+    assert count == 0
+
+
+@pytest.mark.skipif(SigningKey is None, reason="PyNaCl not installed")
+def test_relay_register_accepts_valid_signature(client):
+    resp = client.post("/relay/register", json=_signed_registration_payload())
+
+    assert resp.status_code == 201
+    body = resp.get_json()
+    assert body["ok"] is True
+    assert body["signature_verified"] is True
+
+
+def test_relay_register_requires_signature_before_issuing_token(client):
+    payload = _registration_payload()
+    payload.pop("signature")
+
+    resp = client.post("/relay/register", json=payload)
+    assert resp.status_code == 400
+    body = resp.get_json()
+    assert body and "signature required" in body.get("error", "").lower()
+
+    conn = sqlite3.connect(beacon_chat.DB_PATH)
+    try:
+        count = conn.execute("SELECT COUNT(*) FROM relay_agents").fetchone()[0]
+    finally:
+        conn.close()
+    assert count == 0
+
+
+def test_relay_register_rejects_invalid_signature_without_writing(client, monkeypatch):
+    monkeypatch.setattr(beacon_chat, "verify_ed25519", lambda *_args, **_kwargs: False)
+
+    resp = client.post("/relay/register", json=_registration_payload())
+    assert resp.status_code == 403
+    body = resp.get_json()
+    assert body and "invalid" in body.get("error", "").lower()
+
     conn = sqlite3.connect(beacon_chat.DB_PATH)
     try:
         count = conn.execute("SELECT COUNT(*) FROM relay_agents").fetchone()[0]

--- a/tests/test_revocation_rotation.py
+++ b/tests/test_revocation_rotation.py
@@ -74,18 +74,24 @@ class TestKeyRevocationRotation(unittest.TestCase):
         
         self._insert_agent(agent_id, pubkey, status="revoked")
         
-        # Try to register again with same pubkey
-        response = self.client.post(
-            "/relay/register",
-            json={
-                "pubkey_hex": pubkey,
-                "model_id": "new-model",
-                "name": "New Name",
-                "provider": "beacon"
-            }
-        )
-        self.assertEqual(response.status_code, 403)
-        self.assertIn("revoked", response.get_json()["error"])
+        # Try to register again with same pubkey and a valid ownership proof.
+        original_verify = beacon_chat.verify_ed25519
+        beacon_chat.verify_ed25519 = lambda *_args, **_kwargs: True
+        try:
+            response = self.client.post(
+                "/relay/register",
+                json={
+                    "pubkey_hex": pubkey,
+                    "model_id": "new-model",
+                    "name": "New Name",
+                    "provider": "beacon",
+                    "signature": "aa" * 64,
+                }
+            )
+            self.assertEqual(response.status_code, 403)
+            self.assertIn("revoked", response.get_json()["error"])
+        finally:
+            beacon_chat.verify_ed25519 = original_verify
 
     @unittest.skipUnless(HAS_NACL, "pynacl not installed")
     def test_key_rotation_success(self):


### PR DESCRIPTION
## Description
Harden the Beacon Atlas legacy relay registration path from Scottcjn/beacon-skill#862.

This PR addresses only the H2 slice: `/relay/register` previously treated the Ed25519 ownership signature as optional, so an unsigned registration could bind the derived relay identity and receive a fresh `relay_token`. The hardened `/relay/ping` path already requires ownership proof for new agents; this brings `/relay/register` up to the same fail-closed boundary before any token is issued or row is upserted.

## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update

## Problem / Impact
- Problem: `signature` was optional on `/relay/register`.
- Impact: legacy registration could bypass the hardened relay controls called out in #862 and mint/update relay credentials without proving ownership of the public key.
- Scope boundary: this does not touch `/contracts`, `/beacon/join`, deployment settings, payout logic, admin keys, or production wallets.

## Deployed surface evidence
- Scottcjn/beacon-skill#862 is a Scott-authored security issue for Beacon Atlas legacy relay endpoints.
- Safe live probe: `OPTIONS https://rustchain.org/beacon/relay/register` returns `204` through nginx with `Access-Control-Allow-Methods: POST, GET, OPTIONS`, showing the route is production-reachable without issuing a token or registering an agent.

## Fix
- Require `signature` on `/relay/register` before deriving/upserting relay identity state.
- Keep existing fail-closed behavior when signature verification is unavailable.
- Keep invalid signatures rejected before any `relay_agents` row is written.

## Testing
- `python3 -m pytest -q tests/test_relay_register_security.py tests/test_collaborator_matcher.py tests/test_revocation_rotation.py tests/test_relay_ping_security.py` -> 25 passed
- `git diff --check` -> passed
- `python3 -m py_compile atlas/beacon_chat.py tests/test_relay_register_security.py tests/test_collaborator_matcher.py tests/test_revocation_rotation.py` -> passed

Related: Scottcjn/beacon-skill#862

## Bounty Claim
- Issue number: #862
- Wallet ID: RTC47bc28896a1a4bf240d1fd780f4559b242bcd945