### PR TITLE
fix: require relay token for contract writes

### DIFF
--- a/atlas/beacon_chat.py
+++ b/atlas/beacon_chat.py
@@ -831,7 +831,7 @@ def list_contracts():
         resp = jsonify({})
         resp.headers["Access-Control-Allow-Origin"] = "*"
         resp.headers["Access-Control-Allow-Methods"] = "GET, POST"
-        resp.headers["Access-Control-Allow-Headers"] = "Content-Type"
+        resp.headers["Access-Control-Allow-Headers"] = "Content-Type, Authorization"
         return resp, 204
 
     db = get_db()
@@ -846,6 +846,39 @@ def list_contracts():
             "created_at": r["created_at"], "updated_at": r["updated_at"],
         })
     return cors_json(contracts)
+
+
+def _authenticated_relay_agent_id():
+    """Return the registered relay agent for the Bearer token on state-changing APIs."""
+    auth = request.headers.get("Authorization", "")
+    if not auth.startswith("Bearer "):
+        return None, cors_json({"error": "Missing Authorization: Bearer <relay_token>"}, 401)
+
+    token = auth[7:].strip()
+    if not token:
+        return None, cors_json({"error": "Missing Authorization: Bearer <relay_token>"}, 401)
+
+    row = get_db().execute(
+        "SELECT agent_id, token_expires FROM relay_agents WHERE relay_token = ?",
+        (token,),
+    ).fetchone()
+    if not row:
+        return None, cors_json({"error": "Invalid relay token", "code": "AUTH_FAILED"}, 403)
+    if row["token_expires"] < time.time():
+        return None, cors_json({"error": "Token expired — re-register", "code": "TOKEN_EXPIRED"}, 401)
+    return row["agent_id"], None
+
+
+def _require_contract_party_token(allowed_agent_ids):
+    agent_id, error = _authenticated_relay_agent_id()
+    if error:
+        return None, error
+    if agent_id not in allowed_agent_ids:
+        return None, cors_json({
+            "error": "Relay token is not authorized for this contract",
+            "code": "AUTH_FAILED",
+        }, 403)
+    return agent_id, None
 
 
 @app.route("/api/contracts", methods=["POST"])
@@ -897,6 +930,10 @@ def create_contract():
     if errors:
         return cors_json({"error": "; ".join(errors)}, 400)
 
+    _, auth_error = _require_contract_party_token({from_agent})
+    if auth_error:
+        return auth_error
+
     contract_id = f"ctr_{uuid.uuid4().hex[:8]}"
     db = get_db()
     db.execute(
@@ -921,7 +958,7 @@ def update_contract(contract_id):
         resp = jsonify({})
         resp.headers["Access-Control-Allow-Origin"] = "*"
         resp.headers["Access-Control-Allow-Methods"] = "PATCH"
-        resp.headers["Access-Control-Allow-Headers"] = "Content-Type"
+        resp.headers["Access-Control-Allow-Headers"] = "Content-Type, Authorization"
         return resp, 204
 
     data = request.get_json(silent=True)
@@ -933,9 +970,16 @@ def update_contract(contract_id):
         return cors_json({"error": f"Invalid state (must be: {', '.join(VALID_CONTRACT_STATES)})"}, 400)
 
     db = get_db()
-    existing = db.execute("SELECT id FROM contracts WHERE id = ?", (contract_id,)).fetchone()
+    existing = db.execute(
+        "SELECT id, from_agent, to_agent FROM contracts WHERE id = ?",
+        (contract_id,),
+    ).fetchone()
     if not existing:
         return cors_json({"error": "Contract not found"}, 404)
+
+    _, auth_error = _require_contract_party_token({existing["from_agent"], existing["to_agent"]})
+    if auth_error:
+        return auth_error
 
     db.execute("UPDATE contracts SET state = ?, updated_at = ? WHERE id = ?", (new_state, time.time(), contract_id))
     db.commit()

--- a/tests/test_atlas_rate_limit.py
+++ b/tests/test_atlas_rate_limit.py
@@ -1,5 +1,6 @@
 import importlib.util
 import sqlite3
+import time
 from pathlib import Path
 
 
@@ -38,6 +39,40 @@ def setup_function():
     )
     conn.commit()
     conn.close()
+
+
+def _upsert_relay_agent(agent_id, token):
+    now = time.time()
+    conn = sqlite3.connect(beacon_chat.DB_PATH)
+    try:
+        conn.execute(
+            """
+            INSERT OR REPLACE INTO relay_agents (
+                agent_id, pubkey_hex, model_id, provider, capabilities, webhook_url,
+                relay_token, token_expires, name, status, beat_count, registered_at,
+                last_heartbeat, metadata
+            ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+            """,
+            (
+                agent_id,
+                "11" * 32,
+                "test-model",
+                "beacon",
+                "[]",
+                "",
+                token,
+                now + 3600,
+                agent_id,
+                "active",
+                1,
+                now,
+                now,
+                "{}",
+            ),
+        )
+        conn.commit()
+    finally:
+        conn.close()
 
 
 def test_rate_limiter_ttl_cleanup_and_limit():
@@ -93,11 +128,15 @@ def test_api_write_limit_is_per_ip():
     beacon_chat.app.config["TESTING"] = True
     beacon_chat.app.config["RATE_LIMIT_WRITE_PER_MIN"] = 1
 
+    _upsert_relay_agent("bcn_rate_from", "relay_rate_from_token")
+    _upsert_relay_agent("bcn_rate_to", "relay_rate_to_token")
+
     client = beacon_chat.app.test_client()
-    payload = {"from": "bcn_sophia_elya", "to": "bcn_deep_seeker", "type": "rent", "amount": 1, "term": "7d"}
-    r1 = client.post("/api/contracts", json=payload, environ_overrides={"REMOTE_ADDR": "10.10.10.1"})
-    r2 = client.post("/api/contracts", json=payload, environ_overrides={"REMOTE_ADDR": "10.10.10.1"})
-    r3 = client.post("/api/contracts", json=payload, environ_overrides={"REMOTE_ADDR": "10.10.10.2"})
+    payload = {"from": "bcn_rate_from", "to": "bcn_rate_to", "type": "rent", "amount": 1, "term": "7d"}
+    headers = {"Authorization": "Bearer relay_rate_from_token"}
+    r1 = client.post("/api/contracts", headers=headers, json=payload, environ_overrides={"REMOTE_ADDR": "10.10.10.1"})
+    r2 = client.post("/api/contracts", headers=headers, json=payload, environ_overrides={"REMOTE_ADDR": "10.10.10.1"})
+    r3 = client.post("/api/contracts", headers=headers, json=payload, environ_overrides={"REMOTE_ADDR": "10.10.10.2"})
 
     assert r1.status_code == 201
     assert r2.status_code == 429

--- a/tests/test_contract_auth_security.py
+++ b/tests/test_contract_auth_security.py
@@ -1,0 +1,181 @@
+import sqlite3
+import tempfile
+import time
+import unittest
+from typing import Optional
+
+from atlas import beacon_chat
+
+
+class TestContractAuthSecurity(unittest.TestCase):
+    def setUp(self) -> None:
+        self._tmp = tempfile.TemporaryDirectory()
+        self._orig_db_path = beacon_chat.DB_PATH
+        beacon_chat.DB_PATH = f"{self._tmp.name}/beacon_atlas_test.db"
+        beacon_chat.ATLAS_RATE_LIMITER._entries.clear()
+        beacon_chat.ATLAS_RATE_LIMITER._last_cleanup = 0.0
+        beacon_chat.init_db()
+        beacon_chat.app.config["TESTING"] = True
+        self.client = beacon_chat.app.test_client()
+
+    def tearDown(self) -> None:
+        beacon_chat.DB_PATH = self._orig_db_path
+        self._tmp.cleanup()
+
+    def _insert_relay_agent(
+        self,
+        agent_id: str,
+        token: str,
+        *,
+        token_expires: Optional[float] = None,
+    ) -> None:
+        now = time.time()
+        if token_expires is None:
+            token_expires = now + 3600
+
+        with beacon_chat.app.app_context():
+            db = beacon_chat.get_db()
+            db.execute(
+                """
+                INSERT INTO relay_agents (
+                    agent_id, pubkey_hex, model_id, provider, capabilities, webhook_url,
+                    relay_token, token_expires, name, status, beat_count, registered_at,
+                    last_heartbeat, metadata
+                ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+                """,
+                (
+                    agent_id,
+                    "11" * 32,
+                    "test-model",
+                    "beacon",
+                    "[]",
+                    "",
+                    token,
+                    token_expires,
+                    agent_id,
+                    "active",
+                    1,
+                    now,
+                    now,
+                    "{}",
+                ),
+            )
+            db.commit()
+
+    def _contract_payload(self) -> dict:
+        return {
+            "from": "bcn_contract_from",
+            "to": "bcn_contract_to",
+            "type": "rent",
+            "amount": 1,
+            "term": "7d",
+        }
+
+    def _contract_count(self) -> int:
+        conn = sqlite3.connect(beacon_chat.DB_PATH)
+        try:
+            return conn.execute(
+                "SELECT COUNT(*) FROM contracts WHERE from_agent = ?",
+                ("bcn_contract_from",),
+            ).fetchone()[0]
+        finally:
+            conn.close()
+
+    def _contract_state(self, contract_id: str) -> str:
+        conn = sqlite3.connect(beacon_chat.DB_PATH)
+        try:
+            return conn.execute(
+                "SELECT state FROM contracts WHERE id = ?",
+                (contract_id,),
+            ).fetchone()[0]
+        finally:
+            conn.close()
+
+    def test_contract_create_requires_from_agent_relay_token(self) -> None:
+        self._insert_relay_agent("bcn_contract_from", "relay_from_token")
+        self._insert_relay_agent("bcn_contract_to", "relay_to_token")
+
+        response = self.client.post("/api/contracts", json=self._contract_payload())
+
+        self.assertEqual(response.status_code, 401)
+        self.assertEqual(self._contract_count(), 0)
+
+    def test_contract_create_rejects_non_initiator_relay_token(self) -> None:
+        self._insert_relay_agent("bcn_contract_from", "relay_from_token")
+        self._insert_relay_agent("bcn_contract_to", "relay_to_token")
+
+        response = self.client.post(
+            "/api/contracts",
+            headers={"Authorization": "Bearer relay_to_token"},
+            json=self._contract_payload(),
+        )
+
+        self.assertEqual(response.status_code, 403)
+        self.assertEqual(self._contract_count(), 0)
+
+    def test_contract_create_accepts_from_agent_relay_token(self) -> None:
+        self._insert_relay_agent("bcn_contract_from", "relay_from_token")
+        self._insert_relay_agent("bcn_contract_to", "relay_to_token")
+
+        response = self.client.post(
+            "/api/contracts",
+            headers={"Authorization": "Bearer relay_from_token"},
+            json=self._contract_payload(),
+        )
+
+        self.assertEqual(response.status_code, 201)
+        payload = response.get_json()
+        self.assertEqual(payload["from"], "bcn_contract_from")
+        self.assertEqual(payload["to"], "bcn_contract_to")
+        self.assertEqual(self._contract_count(), 1)
+
+    def test_contract_patch_requires_registered_party_relay_token(self) -> None:
+        self._insert_relay_agent("bcn_contract_from", "relay_from_token")
+        self._insert_relay_agent("bcn_contract_to", "relay_to_token")
+        self._insert_relay_agent("bcn_contract_outsider", "relay_outsider_token")
+        now = time.time()
+
+        with beacon_chat.app.app_context():
+            db = beacon_chat.get_db()
+            db.execute(
+                """
+                INSERT INTO contracts (
+                    id, type, from_agent, to_agent, amount, currency, state, term,
+                    created_at, updated_at
+                ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+                """,
+                (
+                    "ctr_auth_test",
+                    "rent",
+                    "bcn_contract_from",
+                    "bcn_contract_to",
+                    1,
+                    "RTC",
+                    "offered",
+                    "7d",
+                    now,
+                    now,
+                ),
+            )
+            db.commit()
+
+        missing = self.client.patch("/api/contracts/ctr_auth_test", json={"state": "active"})
+        outsider = self.client.patch(
+            "/api/contracts/ctr_auth_test",
+            headers={"Authorization": "Bearer relay_outsider_token"},
+            json={"state": "active"},
+        )
+        party = self.client.patch(
+            "/api/contracts/ctr_auth_test",
+            headers={"Authorization": "Bearer relay_to_token"},
+            json={"state": "active"},
+        )
+
+        self.assertEqual(missing.status_code, 401)
+        self.assertEqual(outsider.status_code, 403)
+        self.assertEqual(party.status_code, 200)
+        self.assertEqual(self._contract_state("ctr_auth_test"), "active")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Problem

Related: Scottcjn/beacon-skill#862, focused on the H4 contract-auth slice.

`/api/contracts` currently allows state-changing writes without proving the caller owns either contract party:

- `POST /api/contracts` can create a contract for arbitrary valid agents.
- `PATCH /api/contracts/<id>` can move an existing contract into another state.

I verified the deployed route is reachable with safe, non-writing probes only: `OPTIONS https://rustchain.org/beacon/api/contracts` advertises POST/PATCH, and an invalid POST reaches server-side validation without requiring auth. I did not create or modify production contracts.

## Fix

- Keep read-only `GET /api/contracts` public.
- Require `Authorization: Bearer <relay_token>` for `POST /api/contracts`.
- Require the token to belong to the resolved `from` agent when creating a contract.
- Require the token to belong to either existing contract party before PATCH state changes.
- Preserve existing amount/state/term validation and write rate-limiting semantics.
- Add `Authorization` to the contract CORS preflight allow-list.

## Tests

- `python3 -m pytest -q tests/test_contract_auth_security.py tests/test_atlas_rate_limit.py tests/test_dashboard.py` -> 17 passed
- `/tmp/druid-beacon-build-venv/bin/python -m build` -> passed
- `python3 -m py_compile atlas/beacon_chat.py tests/test_contract_auth_security.py tests/test_atlas_rate_limit.py` -> passed
- `git diff --check` -> passed

## Scope / non-goals

This PR does not change read-only contract listing, relay registration, `/beacon/join`, payout logic, admin keys, production wallets, reputation scoring rules, contract amounts, or contract state names. It only adds relay-token ownership checks around contract writes.

## Bounty claim

wallet: RTC47bc28896a1a4bf240d1fd780f4559b242bcd945
