### PR TITLE
fix: restore heartbeat not-registered code

### DIFF
--- a/atlas/beacon_chat.py
+++ b/atlas/beacon_chat.py
@@ -1156,7 +1156,7 @@ def relay_heartbeat():
         # and receive a valid relay_token.
         return cors_json({
             "error": "Unknown agent — register first via /relay/register",
-            "code": "AGENT_NOT_FOUND"
+            "code": "AGENT_NOT_REGISTERED"
 
         }, 404)
 


### PR DESCRIPTION
## Problem

Related: Scottcjn/beacon-skill#862 and the earlier H1 relay heartbeat hardening.

While validating the current relay heartbeat security tests, `tests/test_relay_heartbeat_security.py` fails on main because the unknown-agent heartbeat path returns the right HTTP status and message but the wrong machine-readable code:

- expected by the regression test: `AGENT_NOT_REGISTERED`
- current handler: `AGENT_NOT_FOUND`

That leaves the H1 regression coverage red even though the auth behavior itself is hardened.

## Fix

Restore the response code for unknown relay heartbeat agents to `AGENT_NOT_REGISTERED`.

This keeps the existing 404 status and error text, and does not change registration, token validation, heartbeat updates, contract writes, join routes, payout logic, admin keys, or production wallets.

## Tests

- `python3 -m pytest -q tests/test_relay_heartbeat_security.py tests/test_relay_register_security.py tests/test_atlas_rate_limit.py` -> 10 passed
- `python3 -m py_compile atlas/beacon_chat.py tests/test_relay_heartbeat_security.py` -> passed
- `git diff --check` -> passed

## Bounty claim

wallet: RTC47bc28896a1a4bf240d1fd780f4559b242bcd945
