### PR TITLE
fix: require relay token for dns registration

### DIFF
--- a/atlas/beacon_chat.py
+++ b/atlas/beacon_chat.py
@@ -1207,8 +1207,8 @@ def dns_list():
     if request.method == "OPTIONS":
         resp = jsonify({})
         resp.headers["Access-Control-Allow-Origin"] = "*"
-        resp.headers["Access-Control-Allow-Methods"] = "GET"
-        resp.headers["Access-Control-Allow-Headers"] = "Content-Type"
+        resp.headers["Access-Control-Allow-Methods"] = "GET, POST"
+        resp.headers["Access-Control-Allow-Headers"] = "Content-Type, Authorization"
         return resp, 204
     db = get_db()
     rows = db.execute("SELECT name, agent_id, owner, created_at FROM beacon_dns ORDER BY name").fetchall()
@@ -1286,7 +1286,25 @@ def dns_register():
     if errors:
         return cors_json({"error": "; ".join(errors)}, 400)
 
+    auth = request.headers.get("Authorization", "")
+    if not auth.startswith("Bearer "):
+        return cors_json({"error": "Missing Authorization: Bearer <relay_token>"}, 401)
+    token = auth[7:].strip()
+
     db = get_db()
+    agent = db.execute(
+        "SELECT relay_token, token_expires, status FROM relay_agents WHERE agent_id = ?",
+        (agent_id,),
+    ).fetchone()
+    if not agent:
+        return cors_json({"error": "Agent not registered — use /relay/register first"}, 404)
+    if agent["status"] == "revoked":
+        return cors_json({"error": "This agent identity has been revoked"}, 403)
+    if agent["relay_token"] != token:
+        return cors_json({"error": "Authentication failed", "code": "AUTH_FAILED"}, 403)
+    if agent["token_expires"] < time.time():
+        return cors_json({"error": "Token expired — re-register", "code": "TOKEN_EXPIRED"}, 401)
+
     existing = db.execute("SELECT agent_id FROM beacon_dns WHERE name = ?", (name,)).fetchone()
     if existing:
         return cors_json({"error": "Name already registered", "name": name, "current_agent_id": existing["agent_id"]}, 409)

--- a/tests/test_dns_auth_security.py
+++ b/tests/test_dns_auth_security.py
@@ -1,0 +1,145 @@
+import tempfile
+import time
+import unittest
+
+from atlas import beacon_chat
+
+
+class TestDnsAuthSecurity(unittest.TestCase):
+    def setUp(self) -> None:
+        self._tmp = tempfile.TemporaryDirectory()
+        self._orig_db_path = beacon_chat.DB_PATH
+        beacon_chat.DB_PATH = f"{self._tmp.name}/beacon_atlas_test.db"
+        beacon_chat.ATLAS_RATE_LIMITER._entries.clear()
+        beacon_chat.ATLAS_RATE_LIMITER._last_cleanup = 0.0
+        beacon_chat.init_db()
+        beacon_chat.app.config["TESTING"] = True
+        self.client = beacon_chat.app.test_client()
+
+    def tearDown(self) -> None:
+        beacon_chat.DB_PATH = self._orig_db_path
+        self._tmp.cleanup()
+
+    def _insert_agent(
+        self,
+        agent_id: str = "bcn_dnsagent001",
+        relay_token: str = "relay_valid_token",
+        token_expires: float | None = None,
+    ) -> str:
+        now = time.time()
+        if token_expires is None:
+            token_expires = now + 3600
+        with beacon_chat.app.app_context():
+            db = beacon_chat.get_db()
+            db.execute(
+                """
+                INSERT INTO relay_agents (
+                    agent_id, pubkey_hex, model_id, provider, capabilities, webhook_url,
+                    relay_token, token_expires, name, status, beat_count, registered_at,
+                    last_heartbeat, metadata
+                ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+                """,
+                (
+                    agent_id,
+                    "11" * 32,
+                    "test-model",
+                    "beacon",
+                    "[]",
+                    "",
+                    relay_token,
+                    token_expires,
+                    "DNS Agent",
+                    "active",
+                    1,
+                    now,
+                    now,
+                    "{}",
+                ),
+            )
+            db.commit()
+        return agent_id
+
+    def test_dns_register_requires_relay_token_for_target_agent(self) -> None:
+        agent_id = self._insert_agent()
+
+        response = self.client.post(
+            "/api/dns",
+            json={"name": "dns-agent", "agent_id": agent_id, "owner": "beacon"},
+        )
+
+        self.assertEqual(response.status_code, 401)
+        payload = response.get_json()
+        self.assertIn("Authorization", payload["error"])
+
+        with beacon_chat.app.app_context():
+            db = beacon_chat.get_db()
+            row = db.execute("SELECT name FROM beacon_dns WHERE name = ?", ("dns-agent",)).fetchone()
+        self.assertIsNone(row)
+
+    def test_dns_register_rejects_wrong_relay_token(self) -> None:
+        agent_id = self._insert_agent()
+
+        response = self.client.post(
+            "/api/dns",
+            headers={"Authorization": "Bearer relay_wrong_token"},
+            json={"name": "dns-agent", "agent_id": agent_id},
+        )
+
+        self.assertEqual(response.status_code, 403)
+        self.assertEqual(response.get_json()["code"], "AUTH_FAILED")
+
+    def test_dns_register_rejects_expired_relay_token(self) -> None:
+        agent_id = self._insert_agent(token_expires=time.time() - 1)
+
+        response = self.client.post(
+            "/api/dns",
+            headers={"Authorization": "Bearer relay_valid_token"},
+            json={"name": "dns-agent", "agent_id": agent_id},
+        )
+
+        self.assertEqual(response.status_code, 401)
+        self.assertEqual(response.get_json()["code"], "TOKEN_EXPIRED")
+
+    def test_dns_register_accepts_target_agent_relay_token(self) -> None:
+        agent_id = self._insert_agent()
+
+        response = self.client.post(
+            "/api/dns",
+            headers={"Authorization": "Bearer relay_valid_token"},
+            json={"name": "dns-agent", "agent_id": agent_id, "owner": "beacon"},
+        )
+
+        self.assertEqual(response.status_code, 201)
+        payload = response.get_json()
+        self.assertTrue(payload["ok"])
+        self.assertEqual(payload["agent_id"], agent_id)
+        self.assertEqual(payload["name"], "dns-agent")
+
+    def test_dns_lookup_remains_public(self) -> None:
+        now = time.time()
+        with beacon_chat.app.app_context():
+            db = beacon_chat.get_db()
+            db.execute(
+                "INSERT INTO beacon_dns (name, agent_id, owner, created_at) VALUES (?, ?, ?, ?)",
+                ("public-agent", "bcn_publicagent", "beacon", now),
+            )
+            db.commit()
+
+        lookup = self.client.get("/api/dns/public-agent")
+        listing = self.client.get("/api/dns")
+        reverse = self.client.get("/api/dns/reverse/bcn_publicagent")
+
+        self.assertEqual(lookup.status_code, 200)
+        self.assertEqual(listing.status_code, 200)
+        self.assertEqual(reverse.status_code, 200)
+
+    def test_dns_options_allows_authorized_registration_preflight(self) -> None:
+        response = self.client.open("/api/dns", method="OPTIONS")
+
+        self.assertEqual(response.status_code, 204)
+        self.assertIn("POST", response.headers["Access-Control-Allow-Methods"])
+        self.assertIn("Authorization", response.headers["Access-Control-Allow-Headers"])
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Problem

`POST /api/dns` accepted any caller-provided `name` + `agent_id` pair as long as the payload shape was valid. That meant a caller could bind a DNS name to a registered Beacon relay identity without proving control of that target relay agent.

## Impact

Beacon DNS lookup/list/reverse reads are intentionally public, but DNS registration is a state-changing identity mapping. Without a target-agent auth check, names can be hijacked or squatted for another `bcn_` identity, which is the M3 slice from #862.

## Fix

- Require `Authorization: Bearer <relay_token>` before creating DNS records.
- Check that the token belongs to the target `agent_id` and is not expired.
- Reject revoked or unregistered agents before writing the mapping.
- Keep public DNS list/lookup/reverse reads unchanged.
- Update `/api/dns` OPTIONS headers so browser clients can preflight authorized registration.

## Tests

- `python3 -m pytest -q tests/test_dns_auth_security.py tests/test_relay_register_security.py` -> `7 passed`
- `python3 -m py_compile atlas/beacon_chat.py tests/test_dns_auth_security.py` -> passed
- `git diff --check` -> passed

Regression coverage includes missing token, wrong token, expired token, valid target-agent token, public read preservation, and Authorization preflight.

## Scope

This PR is limited to the #862 M3 DNS registration auth boundary. It does not change relay registration, relay messages, contracts, join routes, payouts, admin keys, production wallets, or public DNS read APIs.

---
wallet: RTC47bc28896a1a4bf240d1fd780f4559b242bcd945
