### PR TITLE
fix: verify relay message envelopes

### DIFF
--- a/atlas/beacon_chat.py
+++ b/atlas/beacon_chat.py
@@ -21,6 +21,7 @@ from collections import OrderedDict
 from urllib.parse import urlparse
 import requests as http_requests
 from flask import Flask, request, jsonify, g
+from beacon_skill.codec import verify_envelope
 from beacon_skill.trust import TrustManager
 
 # Optional Ed25519 verification — relay still works without it
@@ -268,6 +269,11 @@ def parse_relay_seo_nonce(data, now):
     return _parse_nonce_fields(data, now, route_name="/relay/heartbeat/seo")
 
 
+def parse_relay_message_nonce(data, now):
+    """Validate and normalize nonce/timestamp fields for signed relay messages."""
+    return _parse_nonce_fields(data, now, route_name="/relay/message")
+
+
 def _reserve_nonce(db, table_name, agent_id, nonce, ts_value, now):
     """Reserve nonce for replay window. Returns False if nonce already seen."""
     db.execute(
@@ -290,6 +296,10 @@ def reserve_relay_ping_nonce(db, agent_id, nonce, ts_value, now):
 
 def reserve_relay_seo_nonce(db, agent_id, nonce, ts_value, now):
     return _reserve_nonce(db, "relay_seo_update_nonces", agent_id, nonce, ts_value, now)
+
+
+def reserve_relay_message_nonce(db, agent_id, nonce, ts_value, now):
+    return _reserve_nonce(db, "relay_message_nonces", agent_id, nonce, ts_value, now)
 
 
 def build_relay_seo_signature_payload(agent_id, seo_url, seo_description, ts_value, nonce):
@@ -452,6 +462,15 @@ def init_db():
     """)
     conn.execute("""
         CREATE TABLE IF NOT EXISTS relay_seo_update_nonces (
+            agent_id TEXT NOT NULL,
+            nonce TEXT NOT NULL,
+            ts REAL NOT NULL,
+            created_at REAL NOT NULL,
+            PRIMARY KEY (agent_id, nonce)
+        )
+    """)
+    conn.execute("""
+        CREATE TABLE IF NOT EXISTS relay_message_nonces (
             agent_id TEXT NOT NULL,
             nonce TEXT NOT NULL,
             ts REAL NOT NULL,
@@ -1468,6 +1487,8 @@ def relay_message():
 
     if not agent_id or not envelope:
         return cors_json({"error": "agent_id and envelope required"}, 400)
+    if not isinstance(envelope, dict):
+        return cors_json({"error": "envelope must be an object"}, 400)
 
     # Authenticate
     db = get_db()
@@ -1478,6 +1499,36 @@ def relay_message():
     now = time.time()
     if row["token_expires"] < now:
         return cors_json({"error": "Token expired — re-register"}, 401)
+    if row["status"] == "revoked":
+        return cors_json({"error": "This agent identity has been revoked"}, 403)
+
+    envelope_agent_id = str(envelope.get("agent_id") or "").strip()
+    if envelope_agent_id != agent_id:
+        return cors_json({
+            "error": "Envelope agent_id must match authenticated relay agent",
+            "code": "AGENT_ID_MISMATCH",
+        }, 403)
+
+    verified = verify_envelope(envelope, known_keys={agent_id: row["pubkey_hex"]})
+    if verified is None:
+        return cors_json({
+            "error": "Envelope signature unverifiable",
+            "code": "SIGNATURE_UNVERIFIABLE",
+        }, 400)
+    if verified is False:
+        return cors_json({
+            "error": "Invalid envelope signature",
+            "code": "SIGNATURE_INVALID",
+        }, 403)
+
+    nonce, ts_value, err = parse_relay_message_nonce(envelope, now)
+    if err:
+        return err
+    if not reserve_relay_message_nonce(db, agent_id, nonce, ts_value, now):
+        return cors_json({
+            "error": "nonce replay detected",
+            "code": "NONCE_REPLAY",
+        }, 409)
 
     # Stamp envelope with relay provenance
     envelope["_relay"] = True

--- a/tests/test_relay_message_security.py
+++ b/tests/test_relay_message_security.py
@@ -1,0 +1,138 @@
+import tempfile
+import time
+import unittest
+
+from atlas import beacon_chat
+from beacon_skill.codec import decode_envelopes, encode_envelope
+from beacon_skill.identity import AgentIdentity
+
+
+class TestRelayMessageSecurity(unittest.TestCase):
+    def setUp(self) -> None:
+        self._tmp = tempfile.TemporaryDirectory()
+        self._orig_db_path = beacon_chat.DB_PATH
+        beacon_chat.DB_PATH = f"{self._tmp.name}/beacon_atlas_test.db"
+        beacon_chat.ATLAS_RATE_LIMITER._entries.clear()
+        beacon_chat.ATLAS_RATE_LIMITER._last_cleanup = 0.0
+        beacon_chat.init_db()
+        beacon_chat.app.config["TESTING"] = True
+        self.client = beacon_chat.app.test_client()
+        self.identity = AgentIdentity.generate()
+        self.agent_id = self.identity.agent_id
+        self.relay_token = "relay_valid_token"
+        self._insert_agent()
+
+    def tearDown(self) -> None:
+        beacon_chat.DB_PATH = self._orig_db_path
+        self._tmp.cleanup()
+
+    def _insert_agent(self) -> None:
+        now = time.time()
+        with beacon_chat.app.app_context():
+            db = beacon_chat.get_db()
+            db.execute(
+                """
+                INSERT INTO relay_agents (
+                    agent_id, pubkey_hex, model_id, provider, capabilities, webhook_url,
+                    relay_token, token_expires, name, status, beat_count, registered_at,
+                    last_heartbeat, metadata
+                ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+                """,
+                (
+                    self.agent_id,
+                    self.identity.public_key_hex,
+                    "test-model",
+                    "beacon",
+                    "[]",
+                    "",
+                    self.relay_token,
+                    now + 3600,
+                    "Message Agent",
+                    "active",
+                    1,
+                    now,
+                    now,
+                    "{}",
+                ),
+            )
+            db.commit()
+
+    def _signed_envelope(self, *, nonce: str | None = None, ts: int | None = None) -> dict:
+        payload = {
+            "kind": "hello",
+            "text": "signed relay message",
+            "ts": int(ts if ts is not None else time.time()),
+        }
+        if nonce is not None:
+            payload["nonce"] = nonce
+        text = encode_envelope(payload, version=2, identity=self.identity, include_pubkey=True)
+        return decode_envelopes(text)[0]
+
+    def _post_message(self, envelope: dict, *, agent_id: str | None = None):
+        return self.client.post(
+            "/relay/message",
+            headers={"Authorization": f"Bearer {self.relay_token}"},
+            json={"agent_id": agent_id or self.agent_id, "envelope": envelope},
+        )
+
+    def test_relay_message_rejects_unsigned_envelope_even_with_valid_token(self) -> None:
+        response = self._post_message(
+            {
+                "kind": "hello",
+                "agent_id": self.agent_id,
+                "nonce": "unsigned-message",
+                "ts": int(time.time()),
+            }
+        )
+
+        self.assertEqual(response.status_code, 400)
+        self.assertEqual(response.get_json()["code"], "SIGNATURE_UNVERIFIABLE")
+
+    def test_relay_message_rejects_tampered_envelope(self) -> None:
+        envelope = self._signed_envelope()
+        envelope["text"] = "tampered after signing"
+
+        response = self._post_message(envelope)
+
+        self.assertEqual(response.status_code, 403)
+        self.assertEqual(response.get_json()["code"], "SIGNATURE_INVALID")
+
+    def test_relay_message_rejects_agent_id_mismatch(self) -> None:
+        other_identity = AgentIdentity.generate()
+        text = encode_envelope(
+            {"kind": "hello", "text": "wrong sender", "ts": int(time.time())},
+            version=2,
+            identity=other_identity,
+            include_pubkey=True,
+        )
+        envelope = decode_envelopes(text)[0]
+
+        response = self._post_message(envelope)
+
+        self.assertEqual(response.status_code, 403)
+        self.assertEqual(response.get_json()["code"], "AGENT_ID_MISMATCH")
+
+    def test_relay_message_rejects_nonce_replay(self) -> None:
+        envelope = self._signed_envelope(nonce="fixed-message-nonce")
+
+        first = self._post_message(envelope)
+        second = self._post_message(envelope)
+
+        self.assertEqual(first.status_code, 200)
+        self.assertEqual(second.status_code, 409)
+        self.assertEqual(second.get_json()["code"], "NONCE_REPLAY")
+
+    def test_relay_message_accepts_valid_signed_envelope(self) -> None:
+        envelope = self._signed_envelope()
+
+        response = self._post_message(envelope)
+
+        self.assertEqual(response.status_code, 200)
+        payload = response.get_json()
+        self.assertTrue(payload["ok"])
+        self.assertTrue(payload["forwarded"])
+        self.assertEqual(payload["nonce"], envelope["nonce"])
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Problem

`/relay/message` authenticated the relay bearer token, but accepted the submitted envelope without verifying that the Beacon v2 envelope signature belonged to the authenticated relay agent. The route also did not reserve message nonces, so replayed envelopes were accepted again.

This is a focused M2 slice from #862.

## Impact

A valid relay token should not be enough to inject arbitrary or replayed message envelopes for an agent. Message submission needs both the existing relay-token check and envelope-level sender/signature/replay validation.

## Fix

- Require `/relay/message` envelopes to be JSON objects.
- Bind the envelope `agent_id` to the authenticated relay agent.
- Verify the Beacon v2 envelope signature against the registered relay public key.
- Reject unverifiable, invalid, mismatched, revoked, and replayed envelopes before relay stamping.
- Add a bounded nonce table for relay message replay protection.

## Tests

Pre-fix, the new relay-message regression tests showed unsigned/tampered/replayed envelopes were accepted. On this branch:

- `python3 -m pytest -q tests/test_relay_message_security.py tests/test_relay_register_security.py tests/test_relay_ping_security.py tests/test_relay_seo_security.py` -> 18 passed
- `python3 -m py_compile atlas/beacon_chat.py tests/test_relay_message_security.py` -> passed
- `git diff --check` -> passed

## Scope boundary

This PR only changes `/relay/message` envelope signature + replay validation. It does not change relay registration, DNS, contracts, join routes, payouts, admin keys, production wallets, or message delivery semantics beyond rejecting forged/replayed envelopes.

Related: Scottcjn/beacon-skill#862

---
wallet: RTC47bc28896a1a4bf240d1fd780f4559b242bcd945
