### PR TITLE
security: gate href scheme on beacon profile and directory pages

### DIFF
--- a/atlas/beacon_chat.py
+++ b/atlas/beacon_chat.py
@@ -2961,6 +2961,27 @@ def relay_ping():
 from datetime import datetime, timezone
 
 
+def _safe_href(url):
+    """Return url only if it uses a safe scheme, else "".
+
+    html.escape neutralizes quote-breakout but does not stop a javascript:
+    or data: URL from running when the string is placed in an href. The
+    /relay/heartbeat/seo write path validates the scheme on input, but the
+    crawlable profile and directory pages are public and also render rows
+    that can arrive from other write paths or predate that check, so gate
+    the scheme again at output.
+    """
+    if not url:
+        return ""
+    candidate = str(url).strip()
+    if candidate.startswith("/") and not candidate.startswith("//"):
+        return candidate
+    scheme = urlparse(candidate).scheme.lower()
+    if scheme in ("http", "https"):
+        return candidate
+    return ""
+
+
 def _agent_profile_html(agent, caps, dns_names, profile=None, matches=None):
     """Build a full crawlable HTML profile page for an agent with dofollow links."""
     name = agent["name"] or agent["agent_id"]
@@ -2998,7 +3019,7 @@ def _agent_profile_html(agent, caps, dns_names, profile=None, matches=None):
     provider = html.escape(provider)
     aid = _urlquote(aid, safe="")
     canonical = html.escape(canonical)
-    seo_url = html.escape(seo_url)
+    seo_url = html.escape(_safe_href(seo_url))
     model_id = html.escape(str(agent["model_id"] or ""))
 
     # Schema.org JSON-LD — SoftwareApplication
@@ -3269,7 +3290,7 @@ def seo_agent_directory():
     for aid, persona in AGENT_PERSONAS.items():
         cards.append(
             f'<div class="agent-card">'
-            f'<h3><a href="/beacon/agent/{aid}">{persona["name"]}</a></h3>'
+            f'<h3><a href="/beacon/agent/{aid}">{html.escape(persona["name"])}</a></h3>'
             f'<span class="status active">active</span> '
             f'<span class="provider">Elyan Labs</span>'
             f'</div>'
@@ -3280,7 +3301,7 @@ def seo_agent_directory():
         assessment = assess_relay_status(int(row["last_heartbeat"]))
         name = html.escape(row["name"] or row["agent_id"])
         provider = html.escape(KNOWN_PROVIDERS.get(row["provider"], row["provider"]))
-        seo_url = html.escape(row["seo_url"] or "")
+        seo_url = html.escape(_safe_href(row["seo_url"]))
         caps = json.loads(row["capabilities"] or "[]")
 
         link_block = ""
@@ -3316,7 +3337,7 @@ def seo_agent_directory():
         },
     }, indent=2)
 
-    html = f"""<!DOCTYPE html>
+    page_html = f"""<!DOCTYPE html>
 <html lang="en">
 <head>
 <meta charset="UTF-8">
@@ -3354,7 +3375,7 @@ a {{ color: #2563eb; }} footer {{ margin-top: 2rem; color: #9ca3af; font-size: 0
 </body>
 </html>"""
 
-    resp = app.response_class(html, mimetype="text/html")
+    resp = app.response_class(page_html, mimetype="text/html")
     resp.headers["Cache-Control"] = "public, max-age=1800"
     return resp
 

--- a/atlas/beacon_chat.py
+++ b/atlas/beacon_chat.py
@@ -2976,7 +2976,13 @@ def _safe_href(url):
     candidate = str(url).strip()
     if candidate.startswith("/") and not candidate.startswith("//"):
         return candidate
-    scheme = urlparse(candidate).scheme.lower()
+    try:
+        scheme = urlparse(candidate).scheme.lower()
+    except ValueError:
+        # Malformed URLs (e.g. bad IPv6 literals like http://[) raise here.
+        # Fail closed rather than let the exception 500 the page, since a single
+        # poisoned seo_url is looped over the whole public directory.
+        return ""
     if scheme in ("http", "https"):
         return candidate
     return ""

--- a/tests/test_profile_directory_href_xss.py
+++ b/tests/test_profile_directory_href_xss.py
@@ -1,0 +1,104 @@
+import os
+import tempfile
+import time
+import unittest
+
+from atlas import beacon_chat
+
+
+class TestProfileDirectoryHrefXss(unittest.TestCase):
+    """Public profile and directory pages must not emit a dangerous href scheme.
+
+    html.escape stops quote-breakout but does not stop a javascript: or data:
+    URL from running when it lands in an href. A row can carry such a seo_url
+    from a write path that skipped scheme validation or from before that check
+    existed, so the crawlable pages gate the scheme again at output.
+    """
+
+    def setUp(self):
+        self._tmp = tempfile.TemporaryDirectory()
+        self._orig_db_path = beacon_chat.DB_PATH
+        self._orig_admin_key = os.environ.get("RC_ADMIN_KEY")
+        os.environ["RC_ADMIN_KEY"] = "test-admin-key"
+        beacon_chat.DB_PATH = f"{self._tmp.name}/beacon_atlas_test.db"
+        beacon_chat.ATLAS_RATE_LIMITER._entries.clear()
+        beacon_chat.ATLAS_RATE_LIMITER._last_cleanup = 0.0
+        beacon_chat.init_db()
+        beacon_chat.app.config["TESTING"] = True
+        self.client = beacon_chat.app.test_client()
+
+    def tearDown(self):
+        beacon_chat.DB_PATH = self._orig_db_path
+        if self._orig_admin_key is None:
+            os.environ.pop("RC_ADMIN_KEY", None)
+        else:
+            os.environ["RC_ADMIN_KEY"] = self._orig_admin_key
+        self._tmp.cleanup()
+
+    def _insert_agent(self, agent_id, seo_url):
+        now = time.time()
+        with beacon_chat.app.app_context():
+            db = beacon_chat.get_db()
+            db.execute(
+                """
+                INSERT INTO relay_agents (
+                    agent_id, pubkey_hex, model_id, provider, capabilities, webhook_url,
+                    relay_token, token_expires, name, status, beat_count, registered_at,
+                    last_heartbeat, metadata, origin_ip, seo_url, seo_description
+                ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+                """,
+                (
+                    agent_id,
+                    "a" * 64,
+                    "test-model",
+                    "beacon",
+                    "[]",
+                    "",
+                    "relay_valid_token",
+                    now + 3600,
+                    "Href Agent",
+                    "active",
+                    1,
+                    now,
+                    now,
+                    "{}",
+                    "127.0.0.1",
+                    seo_url,
+                    "",
+                ),
+            )
+            db.commit()
+
+    def test_javascript_scheme_dropped_on_profile(self):
+        agent_id = "relay_href_profile"
+        self._insert_agent(agent_id, "javascript:alert(document.cookie)")
+        body = self.client.get(f"/beacon/agent/{agent_id}").get_data(as_text=True)
+        self.assertNotIn("javascript:", body)
+
+    def test_javascript_scheme_dropped_on_directory(self):
+        self._insert_agent("relay_href_dir", "javascript:alert(1)")
+        resp = self.client.get("/beacon/directory")
+        # The directory must render (a shadowed html module name previously
+        # made this route 500 whenever a relay agent existed).
+        self.assertEqual(resp.status_code, 200)
+        self.assertNotIn("javascript:", resp.get_data(as_text=True))
+
+    def test_http_scheme_preserved(self):
+        agent_id = "relay_href_ok"
+        self._insert_agent(agent_id, "https://example.com/home")
+        body = self.client.get(f"/beacon/agent/{agent_id}").get_data(as_text=True)
+        self.assertIn('href="https://example.com/home"', body)
+
+    def test_safe_href_helper(self):
+        self.assertEqual(beacon_chat._safe_href("https://a.test"), "https://a.test")
+        self.assertEqual(beacon_chat._safe_href("http://a.test"), "http://a.test")
+        self.assertEqual(beacon_chat._safe_href("/beacon/directory"), "/beacon/directory")
+        self.assertEqual(beacon_chat._safe_href("javascript:alert(1)"), "")
+        self.assertEqual(beacon_chat._safe_href("data:text/html,<script>"), "")
+        self.assertEqual(beacon_chat._safe_href("//evil.test"), "")
+        self.assertEqual(beacon_chat._safe_href(""), "")
+        self.assertEqual(beacon_chat._safe_href(None), "")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
Follow-up hardening for the Beacon Atlas legacy pages in #862. This does not duplicate the merged work; it closes a residual output-context gap and a functional break left by the earlier XSS fix (#863).

DRAFT on purpose. This file is a live relay handling reputation and value, so it needs the tribrain gate before landing.

## What this changes
1. `_safe_href` gate on `seo_url` in both `_agent_profile_html` (`/beacon/agent/<id>`) and `seo_agent_directory` (`/beacon/directory`). `html.escape` stops attribute breakout but does not stop a `javascript:` or `data:` URL from running when the value lands in an `href`. Both pages render `seo_url` as `<a href="{seo_url}">`. The scheme guard allows only http, https, and root-relative links.
2. Fix a pre-existing 500 on `/beacon/directory`. #863 added `html.escape(...)` calls, but the function later binds a local name `html` to the page string, which shadows the `html` module across the whole function. The route raised `UnboundLocalError` and returned 500 whenever any relay agent existed, so the directory escaping was never actually exercised. Renamed the local to `page_html`.
3. Escape the native persona name in the directory for consistency.

## Threat notes (be precise)
- The `javascript:` href gap is defense in depth today. The only live write path for `seo_url` is `/relay/heartbeat/seo`, which validates the scheme on input. This guards rows from any other write path or rows that predate the input check, at the point of output, where URL-context injection belongs.
- The directory 500 is not a security bug on its own, but it means #863's directory XSS fix was dead code. Confirmed on current main: `/beacon/directory` returns 500 as soon as one relay agent is registered.

## Testing
- `python3 -m pytest -q tests/test_profile_directory_href_xss.py tests/test_relay_seo_security.py tests/test_atlas.py tests/test_relay_register_security.py` -> 84 passed
- `python3 -m py_compile atlas/beacon_chat.py` -> ok
- `git diff --check` -> clean
- Pre-existing failures in tests/test_clawnews*.py and tests/test_discord_transport.py are unrelated (network transport) and fail on unmodified main too.

## Scope boundary
Does not touch relay register, contracts, dns, relay message, `/beacon/join`, payout logic, admin keys, or production wallets. The `/beacon/join` retirement (H3) is handled by #888.

Refs #862, #888