### PR TITLE
fix: harden agentfolio-beacon-bridge cross-verification (fix-forward from #855, closes #864)

### DIFF
--- a/examples/agentfolio-beacon-bridge/README.md
+++ b/examples/agentfolio-beacon-bridge/README.md
@@ -1,0 +1,77 @@
+# AgentFolio + Beacon Dual-Layer Trust Bridge
+
+A reference bridge that unifies **Beacon** (hardware-anchored provenance,
+`bcn_` + Ed25519) and **AgentFolio** (marketplace reputation on Solana SATP) into
+one dual-layer trust anchor — the identity target Moltbook refugees need during
+the migration window.
+
+> **v2.0 (fix-forward, [#864](https://github.com/Scottcjn/beacon-skill/issues/864)):**
+> cross-identity verification now *proves* linkage with a mutual signed challenge
+> instead of inferring it from co-existence, name substrings, or a local file.
+> See [`SPEC.md`](./SPEC.md) §0 and §6 for the full list of hardening fixes.
+
+## What it does
+
+- **Cross-identity verification** — a `CrossLinkProof` signed by *both* the Beacon
+  key and the AgentFolio key over one challenge that binds the two IDs. Anything
+  less is rejected.
+- **Composite trust score** — a bounded `[0, 1]` blend
+  (`0.40` beacon fidelity + `0.35` AgentFolio reputation + `0.15` cross-verification
+  + `0.10` endorsements) where `verified` (≥ 0.8) is actually reachable and no
+  malformed input can forge a high score.
+- **Signed trust card** — an Ed25519 attestation over the *whole* card; tamper any
+  field and verification fails.
+- **W3C DID export** — with a valid `publicKeyMultibase` (`z6Mk…`).
+
+## Install
+
+```bash
+pip install -e .            # from the beacon-skill repo root (provides beacon_skill)
+pip install -r examples/agentfolio-beacon-bridge/requirements.txt
+```
+
+## Quick start
+
+```python
+from beacon_skill.identity import AgentIdentity
+from bridge import BridgeClient, Ed25519Signer, create_cross_link_proof
+
+bridge = BridgeClient()
+
+# The operator controls BOTH keys — that is what proves the link.
+beacon = AgentIdentity.generate()      # bcn_ identity
+af     = Ed25519Signer.generate()      # AgentFolio (Solana) key
+
+proof = create_cross_link_proof(beacon, af, af_id="crow-oracle")
+result = bridge.verify_cross_identity(proof)   # verified iff both signatures check
+print(result["verified"], result["reason"])
+
+card = bridge.build_trust_card(beacon, "crow-oracle", cross_link_proof=proof)
+assert BridgeClient.verify_trust_card(card)    # tamper-evident
+
+did = bridge.export_portable_identity(beacon, "crow-oracle")
+print(did["verificationMethod"][0]["publicKeyMultibase"])   # z6Mk…
+```
+
+## Run the demo & tests
+
+```bash
+python  examples/agentfolio-beacon-bridge/demo.py
+pytest  examples/agentfolio-beacon-bridge/test_bridge.py -v
+```
+
+The demo shows a genuine link verifying **and a reputation-borrow forgery being
+rejected**. The test suite uses real Ed25519 keys and covers the forgery cases
+(reputation borrow, mutated payload, non-finite score, expired proof,
+outage-as-not-found) that motivated the rewrite.
+
+## Files
+
+| File | Purpose |
+|------|---------|
+| `bridge.py` | Reference implementation (`BridgeClient`, proofs, scoring, DID export) |
+| `test_bridge.py` | Real-crypto unit + forgery-rejection tests |
+| `demo.py` | Offline end-to-end walkthrough |
+| `SPEC.md` | Integration spec + security considerations |
+
+Bounty: [rustchain-bounties #2890](https://github.com/Scottcjn/rustchain-bounties/issues/2890)

--- a/examples/agentfolio-beacon-bridge/SPEC.md
+++ b/examples/agentfolio-beacon-bridge/SPEC.md
@@ -1,0 +1,212 @@
+# AgentFolio + Beacon Dual-Layer Trust Integration
+
+**Spec Version:** 2.0
+**Original author:** crowniteto
+**Fix-forward (v2.0):** cross-verification hardening per [beacon-skill #864](https://github.com/Scottcjn/beacon-skill/issues/864)
+**Bounty:** [rustchain-bounties #2890](https://github.com/Scottcjn/rustchain-bounties/issues/2890)
+
+---
+
+## 0. What changed in v2.0 (and why)
+
+v1.0 (PR #855) was merged then reverted (commit `c02b608`) because its
+cross-identity verification could be forged: it granted trust when two records
+merely *co-existed*, matched a *substring* of a name, or when a *local JSON file*
+was present — none of which prove that one operator controls both identities.
+v2.0 replaces coincidence with cryptography. The complete list of fixes is in
+§6; the headline is: **linkage is proven by a mutual signed challenge, or it is
+not proven at all.**
+
+---
+
+## 1. Problem Statement
+
+Two complementary agent identity and trust systems exist in the RustChain
+ecosystem but operate in isolation:
+
+| System | Scope | Identity Model | Trust Model |
+|--------|-------|----------------|-------------|
+| **Beacon** | On-chain provenance (hardware-anchored) | `bcn_` + Ed25519 keypair | 6-check fingerprint, relay registration, atlas directory |
+| **AgentFolio** | Marketplace reputation (Solana SATP) | Agent name + SATP on-chain score | V3 genesis score, endorsements, operator verification (OATR) |
+
+Beacon answers *who created this* — cryptographic provenance plus hardware
+attestation. AgentFolio answers *how trustworthy is this agent* — marketplace
+reputation plus skill verification. Neither alone is sufficient; together they
+form the trust anchor Moltbook refugees need. The bridge's job is to combine
+them **without letting either layer's trust be borrowed by an impostor.**
+
+---
+
+## 2. Design Goals
+
+1. **Provable bidirectional linkage** — a Beacon `bcn_` ID and an AgentFolio
+   profile are linked only when the operator demonstrably controls both keys.
+2. **Bounded, well-defined composite score** — a single `[0, 1]` metric whose
+   every tier (including `verified`) is reachable and which no malformed input
+   can inflate.
+3. **Tamper-evident cards** — a trust card is signed as a whole; no field can be
+   altered after signing without detection.
+4. **Fail-closed under outage** — a service being *down* must never be read as an
+   identity being *absent* or *verified*.
+5. **Portable** — export a W3C DID document with valid verification material.
+
+---
+
+## 3. Architecture
+
+### 3.1 Cross-Identity Linkage — Mutual Signed Challenge
+
+Linkage is a claim that one operator controls both `bcn_id` and `af_id`. It is
+proven by a **CrossLinkProof**: a single challenge, signed by *both* keys.
+
+```
+challenge = canonical_json({
+  "typ": "beacon-agentfolio-link", "v": 1,
+  "bcn_id": <bcn_...>, "af_id": <agentfolio id>,
+  "nonce": <128-bit hex>, "issued_at": <unix>, "expires_at": <unix>
+})
+
+CrossLinkProof = {
+  bcn_id, af_id, nonce, issued_at, expires_at,
+  beacon_pubkey_hex,      agentfolio_pubkey_hex,
+  beacon_signature_hex,   agentfolio_signature_hex   # both over `challenge`
+}
+```
+
+**Verification (`verify_cross_identity`) accepts iff ALL hold:**
+
+1. The proof is well-formed and unexpired (`issued_at < now <= expires_at`).
+2. `agent_id_from_pubkey(beacon_pubkey) == bcn_id` — the Beacon key binds to the
+   claimed ID *by construction* (SHA256-derived), so identity is matched exactly,
+   never by name substring.
+3. `Ed25519.verify(beacon_pubkey, beacon_signature, challenge)`.
+4. `agentfolio_pubkey` equals the key AgentFolio publishes for `af_id`
+   (exact match), resolved from the live profile.
+5. `Ed25519.verify(agentfolio_pubkey, agentfolio_signature, challenge)`.
+
+Any failure yields `verified=False` with a precise `reason`
+(`beacon_key_id_mismatch`, `beacon_signature_invalid`, `agentfolio_key_mismatch`,
+`agentfolio_signature_invalid`, `proof_expired`, `agentfolio_unavailable`,
+`agentfolio_identity_not_found`, `malformed_proof`). The nonce + validity window
+bind the proof so it cannot be replayed to link a different pair or reused after
+expiry. **No local file is ever accepted as proof.**
+
+### 3.2 Composite Trust Formula
+
+```
+composite = w_beacon      * beacon_fidelity        # {0, 0.5, 1.0}
+          + w_reputation   * agentfolio_reputation  # clamp(score/100, 0, 1)
+          + w_cross        * cross_component         # 1.0 iff cross-verified, else 0
+          + w_endorsement  * endorsement_factor      # clamp(count/10, 0, 1)
+
+weights:  w_beacon=0.40, w_reputation=0.35, w_cross=0.15, w_endorsement=0.10  (Σ = 1.0)
+levels:   [0, 0.3) unverified | [0.3, 0.6) basic | [0.6, 0.8) trusted | [0.8, 1.0] verified
+```
+
+Every component is normalised to `[0, 1]`; the weights (which sum to 1.0) do all
+the scaling. Therefore the maximum composite is exactly **1.0** and the
+`verified` tier is reachable (a hardware-anchored, high-reputation,
+cross-verified, well-endorsed agent). Every numeric input is passed through a
+finite-guard (`NaN`/`inf`/`None`/non-numeric → 0), so a malformed score can never
+be laundered into a forged `1.0` by the final clamp. `cross_component` is 1.0
+only when a valid CrossLinkProof was supplied — co-existence alone grants nothing.
+
+### 3.3 Signed Trust Card
+
+`build_trust_card` returns a card whose **entire** canonical body (beacon +
+agentfolio + composite + cross_verification + migration) is covered by an
+Ed25519 `attestation`. `verify_trust_card` recomputes the canonical body and
+checks both that the signature verifies and that the attesting key derives to the
+card's Beacon `agent_id`. Mutating *any* field — including the AgentFolio score,
+endorsements, or composite — invalidates the attestation.
+
+### 3.4 Bridge Operations
+
+| Operation | Description |
+|-----------|-------------|
+| `resolve_beacon_to_agentfolio(bcn_id)` | Best-effort *hint* only — suggests a candidate profile; asserts no linkage. |
+| `resolve_agentfolio_to_beacon(af_id)` | Best-effort hint only. |
+| `verify_cross_identity(proof)` | The trust statement — mutual signed challenge (§3.1). |
+| `compute_composite_trust(beacon, af, cross_verified)` | Bounded, non-finite-safe score (§3.2). |
+| `build_trust_card(identity, name, cross_link_proof=None)` | Signed, tamper-evident card (§3.3). |
+| `verify_trust_card(card)` | Verify a card's whole-body attestation. |
+| `dual_register(identity, name, skills)` | Register on both; writes a local *record* (never a proof). |
+| `export_portable_identity(identity, name)` | W3C DID with valid `publicKeyMultibase`. |
+
+---
+
+## 4. Migration Path for Moltbook Refugees
+
+1. **Claim** — the agent calls `dual_register()` with a chosen name.
+2. **Beacon layer** — Ed25519 identity + atlas registration (fingerprint captured).
+3. **AgentFolio layer** — profile creation on SATP (web-authenticated).
+4. **Prove the link** — once the operator holds both keys, they build a
+   CrossLinkProof; the composite score then earns the cross-verification weight.
+5. **Portability** — the W3C DID export anchors the identity to any future platform.
+
+Step 4 is deliberately explicit: onboarding does **not** silently assert linkage.
+
+---
+
+## 5. API Design
+
+```python
+class BridgeClient:
+    def __init__(self, beacon_atlas_url, agentfolio_api_url, trust_weights=None,
+                 cache_ttl_seconds=3600, timeout=15): ...
+    def verify_cross_identity(self, proof: dict) -> dict: ...
+    def compute_composite_trust(self, beacon_data=None, agentfolio_data=None,
+                                cross_verified=False) -> dict: ...
+    def build_trust_card(self, identity, name, skills=None, cross_link_proof=None) -> dict: ...
+    @staticmethod
+    def verify_trust_card(card: dict) -> bool: ...
+    def dual_register(self, identity, name, skills=None) -> dict: ...
+    def export_portable_identity(self, identity, name) -> dict: ...
+
+# Helpers
+def create_cross_link_proof(beacon_signer, agentfolio_signer, af_id, *, ttl_seconds=300) -> dict: ...
+def encode_ed25519_multibase(pubkey_bytes: bytes) -> str: ...   # 'z' + base58btc(0xed01 || pk)
+class Ed25519Signer: ...   # models the AgentFolio/Solana signing key
+```
+
+---
+
+## 6. Security Considerations (fix-forward from #855)
+
+Each item is the resolution of a specific blocking finding.
+
+1. **Linkage requires proof, not co-existence** — `cross_verified` is set only by
+   a valid mutual signed challenge (§3.1). Pairing your Beacon ID with a
+   high-reputation AgentFolio name proves nothing.
+2. **Exact identity match** — the Beacon key binds to `bcn_id` cryptographically;
+   the AgentFolio key must equal the profile's published key. No substring/empty
+   name matching.
+3. **No local-file trust** — the `~/.beacon/bridge/` record is a convenience log,
+   explicitly flagged `is_linkage_proof: false`, and is never read back as proof.
+4. **Whole-card signature** — the attestation covers the entire card, so AF score,
+   endorsements, composite, and migration metadata cannot be mutated post-signing.
+5. **Non-finite scores rejected** — every numeric input is finite-guarded; `NaN`
+   cannot clamp to `1.0` and `None` cannot raise.
+6. **`verified` is reachable** — `[0, 1]` components × unit-sum weights ⇒ max 1.0.
+7. **Atomic, namespaced state** — writes use tmpfile + `os.replace` into
+   `~/.beacon/bridge/` (never `~/.beacon/identity/`), keyed per-agent so links
+   cannot collide or corrupt shared state.
+8. **Outage ≠ absence** — infra errors raise `BridgeUnavailable`; verification
+   fails closed (`agentfolio_unavailable`) rather than reporting "not found".
+9. **Valid DID keys** — `publicKeyMultibase` is `multibase-base58btc(0xed01 ||
+   pubkey)` (`z6Mk…`), matching `Ed25519VerificationKey2020`.
+
+Unchanged good properties: Beacon private keys never leave `~/.beacon/identity/`;
+cross-verification uses public keys only; the trust cache is TTL-bounded.
+
+---
+
+## 7. References
+
+- Beacon source: https://github.com/Scottcjn/beacon-skill
+- Beacon atlas: https://rustchain.org/beacon/
+- AgentFolio: https://agentfolio.bot
+- SATP (Solana Agent Trust Protocol) / OATR (Open Agent Trust Registry)
+- W3C DID Core: https://www.w3.org/TR/did-core/ ; Ed25519 multibase: https://w3id.org/security/suites/ed25519-2020/v1
+- Bounty issue: https://github.com/Scottcjn/rustchain-bounties/issues/2890
+- Fix-forward tracking: https://github.com/Scottcjn/beacon-skill/issues/864

--- a/examples/agentfolio-beacon-bridge/bridge.py
+++ b/examples/agentfolio-beacon-bridge/bridge.py
@@ -1,0 +1,869 @@
+# SPDX-License-Identifier: MIT
+"""AgentFolio + Beacon Dual-Layer Trust Bridge (reference implementation).
+
+Bidirectional bridge connecting Beacon (hardware-anchored provenance) with
+AgentFolio (marketplace reputation on Solana SATP). Provides:
+
+- Cross-resolution: Beacon bcn_ ID <-> AgentFolio agent ID
+- Cross-identity verification: a **mutual signed challenge** that actually
+  proves both identities are controlled by the same operator
+- Composite trust scoring: bounded, non-finite-safe blend of both layers
+- Signed trust card: an Ed25519 attestation over the *entire* card
+- W3C DID export with valid `publicKeyMultibase` (multibase base58btc)
+
+Bounty: https://github.com/Scottcjn/rustchain-bounties/issues/2890
+Tracking / acceptance criteria: https://github.com/Scottcjn/beacon-skill/issues/864
+
+Security model (what a previous revision got wrong, and how this fixes it):
+
+* Linkage is proven by cryptography, never by coincidence. `verify_cross_identity`
+  requires a signature from **both** the Beacon key and the AgentFolio key over a
+  single challenge that binds the two IDs together. Merely existing on both
+  platforms, sharing a substring of a name, or dropping a local JSON file proves
+  nothing and grants no trust.
+* The Beacon public key is bound to its `bcn_` ID by construction
+  (`agent_id_from_pubkey`), so the binding is checked exactly, not by name.
+* Trust scores are validated with `math.isfinite`; a NaN/inf/None can never be
+  laundered into a forged `1.0` by the final clamp.
+* Composite components are in `[0, 1]` and the weights (which sum to 1.0) do the
+  scaling, so the `verified` tier (>= 0.8) is actually reachable.
+* All local state is written atomically (tmpfile + `os.replace`) into
+  `~/.beacon/bridge/`, never into `~/.beacon/identity/`, and is treated as a
+  record/cache only, never as proof.
+* Infrastructure failures (5xx / DNS / timeout) raise `BridgeUnavailable` and are
+  never silently collapsed into "identity not found"; verification fails closed.
+"""
+
+import json
+import math
+import os
+import secrets
+import tempfile
+import time
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any, Dict, List, Optional, Protocol, runtime_checkable
+
+import requests
+from requests.exceptions import RequestException
+
+from cryptography.hazmat.primitives.asymmetric.ed25519 import (
+    Ed25519PrivateKey,
+    Ed25519PublicKey,
+)
+from cryptography.hazmat.primitives.serialization import (
+    Encoding,
+    NoEncryption,
+    PrivateFormat,
+    PublicFormat,
+)
+
+# The bridge reuses beacon-skill's real identity primitives so the crypto is
+# genuine (not a mock): agent IDs are the SHA256-derived `bcn_` IDs, and
+# signatures are verified with the same Ed25519 code the rest of the skill uses.
+from beacon_skill.identity import (
+    AGENT_ID_PREFIX,
+    AgentIdentity,
+    agent_id_from_pubkey,
+)
+
+# ── Default Configuration ────────────────────────────────────────────────────
+
+DEFAULT_BEACON_ATLAS_URL = "https://rustchain.org/beacon"
+DEFAULT_AGENTFOLIO_API_URL = "https://agentfolio.bot/api"
+
+# Weights sum to 1.0. Each component below is normalised to [0, 1], so the
+# maximum achievable composite is exactly 1.0 and every tier is reachable.
+DEFAULT_TRUST_WEIGHTS = {
+    "beacon_fidelity": 0.40,
+    "agentfolio_reputation": 0.35,
+    "cross_verification": 0.15,
+    "endorsement_bonus": 0.10,
+}
+
+# A cross-link proof is short-lived: it binds a fresh nonce + timestamp so a
+# captured proof cannot be replayed indefinitely.
+DEFAULT_PROOF_TTL_SECONDS = 300
+
+LINK_CHALLENGE_TYPE = "beacon-agentfolio-link"
+LINK_CHALLENGE_VERSION = 1
+
+TRUST_LEVELS = [
+    (0.8, "verified"),
+    (0.6, "trusted"),
+    (0.3, "basic"),
+    (0.0, "unverified"),
+]
+
+# Multicodec prefix for an Ed25519 public key (0xed as an unsigned varint).
+_MULTICODEC_ED25519_PUB = b"\xed\x01"
+_BASE58_ALPHABET = "123456789ABCDEFGHJKLMNPQRSTUVWXYZabcdefghijkmnopqrstuvwxyz"
+
+
+class BridgeUnavailable(Exception):
+    """A backing service was unreachable or returned a server error.
+
+    This is deliberately distinct from "identity not found" (which is a ``None``
+    return). Trust decisions fail closed on this exception rather than treating
+    an outage as evidence that an identity does not exist.
+    """
+
+
+@runtime_checkable
+class Signer(Protocol):
+    """Anything that can produce an Ed25519 signature and expose its pubkey.
+
+    ``beacon_skill.identity.AgentIdentity`` satisfies this, as does
+    :class:`Ed25519Signer` (used to model the AgentFolio/Solana side).
+    """
+
+    @property
+    def public_key_hex(self) -> str: ...
+
+    def sign(self, data: bytes) -> bytes: ...
+
+
+class Ed25519Signer:
+    """Minimal Ed25519 signer for the AgentFolio (Solana SATP) side of a link.
+
+    AgentFolio identities are Ed25519 keypairs just like Beacon's, but they are
+    *not* `bcn_` IDs, so they use this plain signer rather than ``AgentIdentity``.
+    """
+
+    def __init__(self, private_key: Ed25519PrivateKey):
+        self._sk = private_key
+        self._pk_bytes = private_key.public_key().public_bytes(
+            Encoding.Raw, PublicFormat.Raw
+        )
+
+    @classmethod
+    def generate(cls) -> "Ed25519Signer":
+        return cls(Ed25519PrivateKey.generate())
+
+    @classmethod
+    def from_private_key_hex(cls, hex_key: str) -> "Ed25519Signer":
+        return cls(Ed25519PrivateKey.from_private_bytes(bytes.fromhex(hex_key)))
+
+    @property
+    def public_key_hex(self) -> str:
+        return self._pk_bytes.hex()
+
+    @property
+    def private_key_hex(self) -> str:
+        return self._sk.private_bytes(
+            Encoding.Raw, PrivateFormat.Raw, NoEncryption()
+        ).hex()
+
+    def sign(self, data: bytes) -> bytes:
+        return self._sk.sign(data)
+
+    def sign_hex(self, data: bytes) -> str:
+        return self.sign(data).hex()
+
+
+# ── Small utilities ──────────────────────────────────────────────────────────
+
+def _trust_level(score: float) -> str:
+    """Map a 0-1 composite score to a trust level label."""
+    if not math.isfinite(score):
+        return "unverified"
+    for threshold, label in TRUST_LEVELS:
+        if score >= threshold:
+            return label
+    return "unverified"
+
+
+def _finite(value: Any, default: float = 0.0) -> float:
+    """Coerce *value* to a finite float, or return *default*.
+
+    ``None``, non-numeric input, and non-finite floats (``NaN``/``inf``) all map
+    to *default*. This is the single choke point that stops a forged or garbage
+    score from ever reaching the composite formula.
+    """
+    if isinstance(value, bool):  # bool is an int subclass; treat as non-numeric
+        return default
+    if isinstance(value, (int, float)):
+        return float(value) if math.isfinite(float(value)) else default
+    if isinstance(value, str):
+        try:
+            f = float(value)
+        except ValueError:
+            return default
+        return f if math.isfinite(f) else default
+    return default
+
+
+def _clamp01(value: float) -> float:
+    if not math.isfinite(value):
+        return 0.0
+    return max(0.0, min(1.0, value))
+
+
+def _base58btc_encode(data: bytes) -> str:
+    """Bitcoin/base58btc encoding (used for multibase `z...` values)."""
+    n = int.from_bytes(data, "big")
+    out = ""
+    while n > 0:
+        n, rem = divmod(n, 58)
+        out = _BASE58_ALPHABET[rem] + out
+    # Preserve leading zero bytes as leading '1's.
+    pad = 0
+    for byte in data:
+        if byte == 0:
+            pad += 1
+        else:
+            break
+    return "1" * pad + out
+
+
+def encode_ed25519_multibase(pubkey_bytes: bytes) -> str:
+    """Encode a raw 32-byte Ed25519 public key as a multibase base58btc string.
+
+    Produces the ``z...`` form required by ``Ed25519VerificationKey2020``:
+    ``multibase-base58btc(0xed01 || raw_public_key)``. The ``z`` prefix denotes
+    base58btc, so (unlike the reverted version) the encoded body is genuine
+    base58btc rather than raw hex.
+    """
+    if not pubkey_bytes:
+        return ""
+    return "z" + _base58btc_encode(_MULTICODEC_ED25519_PUB + pubkey_bytes)
+
+
+def _canonical_bytes(obj: Any) -> bytes:
+    """Deterministic JSON serialisation for signing/verification."""
+    return json.dumps(obj, sort_keys=True, separators=(",", ":")).encode("utf-8")
+
+
+def _atomic_write_text(path: Path, text: str) -> None:
+    """Write *text* to *path* atomically (tmpfile + fsync + os.replace)."""
+    path.parent.mkdir(parents=True, exist_ok=True)
+    fd, tmp = tempfile.mkstemp(dir=str(path.parent), prefix=f".{path.name}.", suffix=".tmp")
+    try:
+        with os.fdopen(fd, "w", encoding="utf-8") as fh:
+            fh.write(text)
+            fh.flush()
+            os.fsync(fh.fileno())
+        os.replace(tmp, path)  # atomic on POSIX and Windows
+    finally:
+        try:
+            os.unlink(tmp)
+        except FileNotFoundError:
+            pass
+
+
+def _verify_ed25519(pubkey_hex: str, signature_hex: str, data: bytes) -> bool:
+    """Verify an Ed25519 signature; any malformed input returns False."""
+    try:
+        pk = Ed25519PublicKey.from_public_bytes(bytes.fromhex(pubkey_hex))
+        pk.verify(bytes.fromhex(signature_hex), data)
+        return True
+    except Exception:
+        return False
+
+
+# ── Cross-link challenge / proof construction ────────────────────────────────
+
+def build_link_challenge(
+    bcn_id: str,
+    af_id: str,
+    nonce: str,
+    issued_at: int,
+    expires_at: int,
+) -> bytes:
+    """Canonical bytes both parties sign to attest a bcn_ <-> AgentFolio link.
+
+    The challenge binds *both* identities plus a nonce and validity window, so a
+    signature over it cannot be replayed to link a different pair or reused after
+    expiry.
+    """
+    return _canonical_bytes(
+        {
+            "typ": LINK_CHALLENGE_TYPE,
+            "v": LINK_CHALLENGE_VERSION,
+            "bcn_id": bcn_id,
+            "af_id": af_id,
+            "nonce": nonce,
+            "issued_at": issued_at,
+            "expires_at": expires_at,
+        }
+    )
+
+
+def create_cross_link_proof(
+    beacon_signer: Signer,
+    agentfolio_signer: Signer,
+    af_id: str,
+    *,
+    ttl_seconds: int = DEFAULT_PROOF_TTL_SECONDS,
+    now: Optional[int] = None,
+) -> Dict[str, Any]:
+    """Build a mutual-signed-challenge proof that the operator controls both IDs.
+
+    The caller must hold *both* private keys (this is exactly what proves the two
+    identities share an operator). ``beacon_signer`` is normally an
+    ``AgentIdentity``; ``agentfolio_signer`` models the AgentFolio/Solana key.
+    """
+    bcn_id = agent_id_from_pubkey(bytes.fromhex(beacon_signer.public_key_hex))
+    issued_at = int(now if now is not None else time.time())
+    expires_at = issued_at + int(ttl_seconds)
+    nonce = secrets.token_hex(16)
+    challenge = build_link_challenge(bcn_id, af_id, nonce, issued_at, expires_at)
+    return {
+        "typ": LINK_CHALLENGE_TYPE,
+        "v": LINK_CHALLENGE_VERSION,
+        "bcn_id": bcn_id,
+        "af_id": af_id,
+        "nonce": nonce,
+        "issued_at": issued_at,
+        "expires_at": expires_at,
+        "beacon_pubkey_hex": beacon_signer.public_key_hex,
+        "agentfolio_pubkey_hex": agentfolio_signer.public_key_hex,
+        "beacon_signature_hex": beacon_signer.sign(challenge).hex(),
+        "agentfolio_signature_hex": agentfolio_signer.sign(challenge).hex(),
+    }
+
+
+# ── Trust Cache ──────────────────────────────────────────────────────────────
+
+class TrustCache:
+    """File-based cache with TTL for trust lookups (atomic writes)."""
+
+    def __init__(self, cache_dir: Optional[Path] = None, ttl_seconds: int = 3600):
+        # Under ~/.beacon/bridge/, never ~/.beacon/identity/.
+        self._dir = cache_dir or Path.home() / ".beacon" / "bridge" / "trust_cache"
+        self._ttl = ttl_seconds
+
+    def get(self, key: str) -> Optional[Dict]:
+        path = self._dir / f"{self._safe_key(key)}.json"
+        if not path.exists():
+            return None
+        try:
+            data = json.loads(path.read_text(encoding="utf-8"))
+            if time.time() - data.get("cached_at", 0) > self._ttl:
+                return None
+            return data["payload"]
+        except (json.JSONDecodeError, KeyError, OSError):
+            return None
+
+    def set(self, key: str, payload: Dict) -> None:
+        path = self._dir / f"{self._safe_key(key)}.json"
+        entry = {"cached_at": time.time(), "payload": payload}
+        _atomic_write_text(
+            path, json.dumps(entry, indent=2, sort_keys=True) + "\n"
+        )
+
+    @staticmethod
+    def _safe_key(key: str) -> str:
+        # Keep cache filenames from escaping the cache dir or colliding.
+        return "".join(c if (c.isalnum() or c in "._-") else "_" for c in key)
+
+
+# ── Bridge Client ────────────────────────────────────────────────────────────
+
+class BridgeClient:
+    """Bidirectional bridge between Beacon and AgentFolio trust systems."""
+
+    def __init__(
+        self,
+        beacon_atlas_url: str = DEFAULT_BEACON_ATLAS_URL,
+        agentfolio_api_url: str = DEFAULT_AGENTFOLIO_API_URL,
+        trust_weights: Optional[Dict[str, float]] = None,
+        cache_ttl_seconds: int = 3600,
+        timeout: int = 15,
+    ):
+        self._beacon_url = beacon_atlas_url.rstrip("/")
+        self._af_url = agentfolio_api_url.rstrip("/")
+        self._weights = trust_weights or dict(DEFAULT_TRUST_WEIGHTS)
+        self._cache = TrustCache(ttl_seconds=cache_ttl_seconds)
+        self._timeout = timeout
+
+    # ── HTTP helpers (infra errors are distinct from not-found) ──
+
+    def _get(self, base: str, path: str) -> Optional[Dict]:
+        """GET JSON. Return None on a genuine 404; raise BridgeUnavailable on any
+        transport error or 5xx so an outage is never read as 'no such identity'.
+        """
+        url = f"{base}{path}"
+        try:
+            resp = requests.get(
+                url,
+                timeout=self._timeout,
+                headers={
+                    "User-Agent": "Beacon-Bridge/2.0.0",
+                    "Accept": "application/json",
+                },
+            )
+        except RequestException as exc:
+            raise BridgeUnavailable(f"request to {url} failed: {exc}") from exc
+        if resp.status_code == 200:
+            try:
+                return resp.json()
+            except ValueError as exc:
+                raise BridgeUnavailable(f"invalid JSON from {url}: {exc}") from exc
+        if resp.status_code == 404:
+            return None
+        if resp.status_code >= 500:
+            raise BridgeUnavailable(f"{url} returned {resp.status_code}")
+        # Other 4xx (401/403/etc.) are not a clean "not found"; fail closed.
+        raise BridgeUnavailable(f"{url} returned {resp.status_code}")
+
+    def _beacon_get(self, path: str) -> Optional[Dict]:
+        return self._get(self._beacon_url, path)
+
+    def _af_get(self, path: str) -> Optional[Dict]:
+        return self._get(self._af_url, path)
+
+    # ── Beacon Atlas lookup ──
+
+    def lookup_beacon_atlas(self, bcn_id: str) -> Optional[Dict]:
+        """Look up an agent in the Beacon atlas by bcn_ ID (exact match)."""
+        cached = self._cache.get(f"beacon_atlas:{bcn_id}")
+        if cached is not None:
+            return cached
+        data = self._beacon_get("/atlas")
+        if isinstance(data, list):
+            for entry in data:
+                if entry.get("agent_id") == bcn_id:
+                    self._cache.set(f"beacon_atlas:{bcn_id}", entry)
+                    return entry
+        return None
+
+    def lookup_beacon_dns(self, name: str) -> Optional[Dict]:
+        """Resolve a human-readable name via Beacon DNS."""
+        cached = self._cache.get(f"beacon_dns:{name}")
+        if cached is not None:
+            return cached
+        data = self._beacon_get(f"/dns/{name}")
+        if data:
+            self._cache.set(f"beacon_dns:{name}", data)
+            return data
+        return None
+
+    # ── AgentFolio lookup ──
+
+    def lookup_agentfolio(self, agent_id: str) -> Optional[Dict]:
+        """Look up an agent on AgentFolio by ID or name (exact profile first)."""
+        cached = self._cache.get(f"agentfolio:{agent_id}")
+        if cached is not None:
+            return cached
+        data = self._af_get(f"/profile/{agent_id}")
+        if isinstance(data, dict) and data.get("name"):
+            self._cache.set(f"agentfolio:{agent_id}", data)
+            return data
+        return None
+
+    # ── Cross-resolution ──
+
+    def resolve_beacon_to_agentfolio(self, bcn_id: str) -> Optional[Dict]:
+        """Resolve a Beacon bcn_ ID to its AgentFolio profile (best-effort hint).
+
+        NOTE: resolution is a *convenience*, not a trust statement. It suggests a
+        candidate AgentFolio profile; it does not assert the two are linked. Use
+        :meth:`verify_cross_identity` (with a signed proof) to establish linkage.
+        """
+        atlas_entry = self.lookup_beacon_atlas(bcn_id)
+        if not atlas_entry:
+            return None
+        name = atlas_entry.get("name", "")
+        if not name:
+            return None
+        return self.lookup_agentfolio(name)
+
+    def resolve_agentfolio_to_beacon(self, af_id: str) -> Optional[Dict]:
+        """Resolve an AgentFolio agent ID to a candidate Beacon atlas entry.
+
+        Convenience only — see :meth:`resolve_beacon_to_agentfolio`.
+        """
+        af_profile = self.lookup_agentfolio(af_id)
+        if not af_profile:
+            return None
+        name = af_profile.get("name", "")
+        if not name:
+            return None
+        dns_result = self.lookup_beacon_dns(name)
+        if dns_result:
+            return dns_result
+        return None
+
+    # ── Composite trust scoring ──
+
+    def compute_composite_trust(
+        self,
+        beacon_data: Optional[Dict] = None,
+        agentfolio_data: Optional[Dict] = None,
+        cross_verified: bool = False,
+    ) -> Dict[str, Any]:
+        """Compute the composite trust score from both layers.
+
+        ``cross_verified`` must reflect a *proven* linkage (see
+        :meth:`verify_cross_identity`); it is False unless a valid signed proof
+        was supplied. The mere co-existence of two records grants no bonus.
+
+        All component values are normalised to ``[0, 1]`` and every numeric input
+        is passed through :func:`_finite`, so the result is always a finite value
+        in ``[0, 1]`` and the ``verified`` tier (>= 0.8) is reachable.
+        """
+        w = self._weights
+
+        beacon_fidelity = 0.0
+        if beacon_data:
+            status = beacon_data.get("status", beacon_data.get("atlas_status", ""))
+            if status == "active":
+                has_fp = bool(
+                    beacon_data.get("hardware_fingerprint")
+                    or beacon_data.get("fingerprint")
+                )
+                beacon_fidelity = 1.0 if has_fp else 0.5
+
+        af_reputation = 0.0
+        if agentfolio_data:
+            af_reputation = _clamp01(_finite(agentfolio_data.get("trust_score", 0)) / 100.0)
+
+        cross_component = 1.0 if cross_verified else 0.0
+
+        endorsement_factor = 0.0
+        if agentfolio_data:
+            endorsement_factor = _clamp01(
+                _finite(agentfolio_data.get("endorsement_count", 0)) / 10.0
+            )
+
+        composite = (
+            _finite(w.get("beacon_fidelity", 0.40)) * beacon_fidelity
+            + _finite(w.get("agentfolio_reputation", 0.35)) * af_reputation
+            + _finite(w.get("cross_verification", 0.15)) * cross_component
+            + _finite(w.get("endorsement_bonus", 0.10)) * endorsement_factor
+        )
+        composite = _clamp01(composite)
+
+        return {
+            "score": round(composite, 4),
+            "components": {
+                "beacon_fidelity": round(beacon_fidelity, 4),
+                "agentfolio_reputation": round(af_reputation, 4),
+                "cross_verified": cross_verified,
+                "endorsement_factor": round(endorsement_factor, 4),
+            },
+            "level": _trust_level(composite),
+            "computed_at": datetime.now(timezone.utc).isoformat(),
+        }
+
+    # ── Cross-identity verification (the core fix) ──
+
+    def verify_cross_identity(self, proof: Dict[str, Any]) -> Dict[str, Any]:
+        """Verify that a Beacon identity and an AgentFolio identity share an operator.
+
+        Linkage is accepted only when the proof carries a valid Ed25519 signature
+        from **both** sides over a single challenge that binds the two IDs:
+
+        1. The Beacon public key must derive to ``bcn_id`` (exact, cryptographic).
+        2. The Beacon signature over the challenge must verify.
+        3. The AgentFolio public key must equal the key AgentFolio publishes for
+           ``af_id`` (exact), and the AgentFolio signature must verify.
+
+        Any failure — malformed proof, expired window, key/ID mismatch, bad
+        signature — yields ``verified=False`` with a precise ``reason``. Backend
+        outages fail closed (``agentfolio_unavailable``), never silently pass.
+        """
+        result = {
+            "verified": False,
+            "method": "mutual_signed_challenge",
+            "reason": None,
+            "bcn_id": proof.get("bcn_id") if isinstance(proof, dict) else None,
+            "af_id": proof.get("af_id") if isinstance(proof, dict) else None,
+        }
+
+        if not isinstance(proof, dict):
+            result["reason"] = "malformed_proof"
+            return result
+
+        required = (
+            "bcn_id", "af_id", "nonce", "issued_at", "expires_at",
+            "beacon_pubkey_hex", "agentfolio_pubkey_hex",
+            "beacon_signature_hex", "agentfolio_signature_hex",
+        )
+        if any(proof.get(k) in (None, "") for k in required):
+            result["reason"] = "malformed_proof"
+            return result
+
+        bcn_id = proof["bcn_id"]
+        af_id = proof["af_id"]
+
+        # Validity window (rejects stale/replayed proofs).
+        try:
+            issued_at = int(proof["issued_at"])
+            expires_at = int(proof["expires_at"])
+        except (TypeError, ValueError):
+            result["reason"] = "malformed_proof"
+            return result
+        now = int(time.time())
+        if expires_at <= issued_at or now > expires_at:
+            result["reason"] = "proof_expired"
+            return result
+
+        # (1) The Beacon pubkey must bind to bcn_id by construction — exact match,
+        # not a name substring.
+        try:
+            beacon_pub_bytes = bytes.fromhex(proof["beacon_pubkey_hex"])
+        except ValueError:
+            result["reason"] = "malformed_proof"
+            return result
+        if not (bcn_id.startswith(AGENT_ID_PREFIX)
+                and agent_id_from_pubkey(beacon_pub_bytes) == bcn_id):
+            result["reason"] = "beacon_key_id_mismatch"
+            return result
+
+        # (2) The Beacon signature over the bound challenge must verify.
+        challenge = build_link_challenge(
+            bcn_id, af_id, proof["nonce"], issued_at, expires_at
+        )
+        if not _verify_ed25519(proof["beacon_pubkey_hex"], proof["beacon_signature_hex"], challenge):
+            result["reason"] = "beacon_signature_invalid"
+            return result
+
+        # (3) The AgentFolio pubkey must be the one AgentFolio publishes for af_id.
+        # An outage here fails closed rather than masquerading as "not found".
+        try:
+            af_profile = self.lookup_agentfolio(af_id)
+        except BridgeUnavailable:
+            result["reason"] = "agentfolio_unavailable"
+            return result
+        if not af_profile:
+            result["reason"] = "agentfolio_identity_not_found"
+            return result
+        published_key = af_profile.get("public_key_hex") or af_profile.get("pubkey_hex")
+        if not published_key or published_key.lower() != proof["agentfolio_pubkey_hex"].lower():
+            result["reason"] = "agentfolio_key_mismatch"
+            return result
+
+        if not _verify_ed25519(
+            proof["agentfolio_pubkey_hex"], proof["agentfolio_signature_hex"], challenge
+        ):
+            result["reason"] = "agentfolio_signature_invalid"
+            return result
+
+        result["verified"] = True
+        result["reason"] = "ok"
+        result["beacon_name"] = None  # linkage is by key, not by name
+        result["agentfolio_name"] = af_profile.get("name", "")
+        return result
+
+    # ── Trust card builder ──
+
+    def build_trust_card(
+        self,
+        identity: Any,
+        name: str,
+        skills: Optional[List[str]] = None,
+        cross_link_proof: Optional[Dict[str, Any]] = None,
+    ) -> Dict[str, Any]:
+        """Build a unified dual-layer trust card, signed as a whole.
+
+        If ``cross_link_proof`` is supplied and verifies, the card is marked
+        cross-verified and the composite score reflects it. The Ed25519
+        ``attestation`` covers the *entire* card body (beacon + agentfolio +
+        composite + migration), so no field can be mutated after signing without
+        invalidating the attestation.
+        """
+        bcn_id = identity.agent_id if hasattr(identity, "agent_id") else str(identity)
+        pubkey_hex = identity.public_key_hex if hasattr(identity, "public_key_hex") else ""
+        beacon_data = self.lookup_beacon_atlas(bcn_id)
+        af_data = self.lookup_agentfolio(name)
+
+        cross_verified = False
+        if cross_link_proof is not None:
+            cross_verified = self.verify_cross_identity(cross_link_proof).get("verified", False)
+
+        beacon_layer = {
+            "agent_id": bcn_id,
+            "public_key_hex": pubkey_hex,
+            "atlas_status": (
+                beacon_data.get("status", beacon_data.get("atlas_status", "unknown"))
+                if beacon_data else "unregistered"
+            ),
+        }
+        if beacon_data:
+            for key in ("hardware_fingerprint", "fingerprint", "city", "region"):
+                if key in beacon_data:
+                    beacon_layer[key] = beacon_data[key]
+
+        af_layer = {"name": name, "skills": skills or []}
+        if af_data:
+            for key in ("agent_id", "trust_score", "verifications", "endorsement_count",
+                        "satp_on_chain", "oatr_operator_verified", "public_key_hex"):
+                if key in af_data:
+                    af_layer[key] = af_data[key]
+        else:
+            af_layer["agent_id"] = f"agent_{name.lower().replace('-', '_')}"
+            af_layer["trust_score"] = 0
+            af_layer["verifications"] = []
+            af_layer["endorsement_count"] = 0
+
+        composite = self.compute_composite_trust(beacon_data, af_data, cross_verified=cross_verified)
+
+        card_body = {
+            "version": "2.0.0",
+            "beacon": beacon_layer,
+            "agentfolio": af_layer,
+            "composite_trust": composite,
+            "cross_verification": {
+                "verified": cross_verified,
+                "method": "mutual_signed_challenge" if cross_verified else "none",
+            },
+            "migration": {"moltbook_refugee": False, "previous_identity": None, "claimed_at": None},
+        }
+
+        # Sign the ENTIRE canonical card body (finding #4). The attestation binds
+        # the signing key too, so a verifier can confirm both integrity and that
+        # the signer controls the card's Beacon identity.
+        if hasattr(identity, "sign"):
+            signature_hex = identity.sign(_canonical_bytes(card_body)).hex()
+            card_body["attestation"] = {
+                "alg": "Ed25519",
+                "public_key_hex": pubkey_hex,
+                "signature_hex": signature_hex,
+                "signed_at": datetime.now(timezone.utc).isoformat(),
+            }
+        return card_body
+
+    @staticmethod
+    def verify_trust_card(card: Dict[str, Any]) -> bool:
+        """Verify a trust card's attestation covers the whole card and binds its key.
+
+        Returns True only if (a) the Ed25519 signature verifies over the canonical
+        card body (attestation removed) and (b) the attesting key derives to the
+        card's Beacon ``agent_id`` — so a card cannot be re-signed by an unrelated
+        key or have any field mutated post-signing.
+        """
+        if not isinstance(card, dict) or "attestation" not in card:
+            return False
+        attestation = card["attestation"]
+        pubkey_hex = attestation.get("public_key_hex", "")
+        signature_hex = attestation.get("signature_hex", "")
+        if not pubkey_hex or not signature_hex:
+            return False
+        try:
+            claimed_agent_id = card.get("beacon", {}).get("agent_id", "")
+            if agent_id_from_pubkey(bytes.fromhex(pubkey_hex)) != claimed_agent_id:
+                return False
+        except ValueError:
+            return False
+        body = {k: v for k, v in card.items() if k != "attestation"}
+        return _verify_ed25519(pubkey_hex, signature_hex, _canonical_bytes(body))
+
+    # ── Dual registration ──
+
+    def dual_register(
+        self,
+        identity: Any,
+        name: str,
+        skills: Optional[List[str]] = None,
+    ) -> Dict[str, Any]:
+        """Register agent on both Beacon atlas and AgentFolio.
+
+        Writes a local cross-link *record* (never treated as proof) atomically
+        into ``~/.beacon/bridge/`` under a per-agent filename, so it cannot
+        collide with another agent's link or corrupt shared state.
+        """
+        bcn_id = identity.agent_id if hasattr(identity, "agent_id") else str(identity)
+
+        beacon_result = {"status": "skipped", "message": "atlas_ping requires beacon-skill daemon"}
+        try:
+            from beacon_skill.atlas_ping import atlas_ping
+            data = atlas_ping(
+                agent_id=bcn_id, name=name,
+                capabilities=skills or ["general"], identity=identity,
+            )
+            beacon_result = {"status": "registered", "data": data}
+        except ImportError as exc:
+            beacon_result = {"status": "partial", "message": f"beacon-skill unavailable: {exc}"}
+        except Exception as exc:  # network / daemon error — reported, not fatal
+            beacon_result = {"status": "partial", "message": str(exc)}
+
+        af_result = {"status": "skipped", "message": "AgentFolio profile creation requires web authentication"}
+        try:
+            existing = self.lookup_agentfolio(name)
+            if existing:
+                af_result = {"status": "existing", "data": existing}
+            else:
+                af_result = {"status": "requires_auth", "message": "Visit agentfolio.bot to create profile"}
+        except BridgeUnavailable as exc:
+            af_result = {"status": "unavailable", "message": str(exc)}
+
+        trust_card = self.build_trust_card(identity, name, skills=skills)
+
+        # Record only — explicitly NOT a linkage proof. A real link requires a
+        # mutual signed challenge via verify_cross_identity().
+        record_dir = Path.home() / ".beacon" / "bridge" / "links"
+        record_path = record_dir / f"{bcn_id}.json"
+        cross_link_record = {
+            "record_type": "bridge_registration",
+            "is_linkage_proof": False,
+            "bcn_id": bcn_id,
+            "agentfolio_name": name,
+            "registered_at": datetime.now(timezone.utc).isoformat(),
+            "beacon_result": beacon_result["status"],
+            "agentfolio_result": af_result["status"],
+        }
+        _atomic_write_text(record_path, json.dumps(cross_link_record, indent=2) + "\n")
+
+        return {
+            "beacon_result": beacon_result,
+            "agentfolio_result": af_result,
+            "trust_card": trust_card,
+            "cross_link_record": str(record_path),
+            "status": "partial" if "partial" in (beacon_result["status"], af_result["status"]) else "ok",
+        }
+
+    # ── W3C DID export ──
+
+    def export_portable_identity(
+        self,
+        identity: Any,
+        name: str,
+    ) -> Dict[str, Any]:
+        """Export a W3C DID-compatible identity document with both trust layers."""
+        bcn_id = identity.agent_id if hasattr(identity, "agent_id") else str(identity)
+        pubkey_hex = identity.public_key_hex if hasattr(identity, "public_key_hex") else ""
+        trust_card = self.build_trust_card(identity, name)
+        composite = trust_card["composite_trust"]
+        did = f"did:beacon:{bcn_id}"
+        now = datetime.now(timezone.utc).isoformat()
+
+        multibase_key = ""
+        if pubkey_hex:
+            try:
+                multibase_key = encode_ed25519_multibase(bytes.fromhex(pubkey_hex))
+            except ValueError:
+                multibase_key = ""
+
+        return {
+            "@context": ["https://www.w3.org/ns/did/v1", "https://w3id.org/security/suites/ed25519-2020/v1"],
+            "id": did,
+            "controller": did,
+            "verificationMethod": [{
+                "id": f"{did}#beacon-key",
+                "type": "Ed25519VerificationKey2020",
+                "controller": did,
+                "publicKeyMultibase": multibase_key,
+            }],
+            "authentication": [f"{did}#beacon-key"],
+            "assertionMethod": [f"{did}#beacon-key"],
+            "service": [{
+                "id": f"{did}#agentfolio",
+                "type": "AgentFolioTrust",
+                "serviceEndpoint": f"https://agentfolio.bot/api/profile/{name}",
+            }, {
+                "id": f"{did}#beacon-atlas",
+                "type": "BeaconAtlas",
+                "serviceEndpoint": f"https://rustchain.org/beacon/atlas/{bcn_id}",
+            }],
+            "trustMetadata": {
+                "compositeScore": composite["score"],
+                "trustLevel": composite["level"],
+                "beaconFidelity": composite["components"]["beacon_fidelity"],
+                "agentfolioReputation": composite["components"]["agentfolio_reputation"],
+                "crossVerified": composite["components"]["cross_verified"],
+                "exportedAt": now,
+            },
+            "alsoKnownAs": [f"agentfolio:{name}", f"beacon:{bcn_id}"],
+        }

--- a/examples/agentfolio-beacon-bridge/demo.py
+++ b/examples/agentfolio-beacon-bridge/demo.py
@@ -1,0 +1,102 @@
+# SPDX-License-Identifier: MIT
+"""Interactive demo for the AgentFolio + Beacon Dual-Layer Trust Bridge.
+
+Runs fully offline with real Ed25519 keys. It shows:
+
+1. A genuine mutual-signed-challenge cross-link verifying.
+2. A reputation-borrow *forgery* being rejected.
+3. A composite score reaching the ``verified`` tier only when cross-verified.
+4. A signed trust card whose attestation breaks if any field is mutated.
+5. A W3C DID export with a valid `publicKeyMultibase`.
+
+Run: python demo.py
+"""
+
+import sys
+from pathlib import Path
+from unittest.mock import patch
+
+sys.path.insert(0, str(Path(__file__).parent))
+from bridge import (
+    BridgeClient,
+    Ed25519Signer,
+    create_cross_link_proof,
+)
+from beacon_skill.identity import AgentIdentity
+
+
+def _profile(signer, name, trust_score, endorsements):
+    return {
+        "agent_id": f"agent_{name.replace('-', '_')}",
+        "name": name,
+        "public_key_hex": signer.public_key_hex,
+        "trust_score": trust_score,
+        "endorsement_count": endorsements,
+        "status": "active",
+    }
+
+
+def main() -> None:
+    bridge = BridgeClient()
+
+    # The operator controls BOTH keys — that is what makes the link real.
+    beacon = AgentIdentity.generate()
+    af = Ed25519Signer.generate()
+    print("Beacon identity :", beacon.agent_id)
+    print("AgentFolio key  :", af.public_key_hex[:16], "…")
+    print()
+
+    profile = _profile(af, "crow-oracle", trust_score=88, endorsements=9)
+
+    # 1) Genuine cross-link ----------------------------------------------------
+    proof = create_cross_link_proof(beacon, af, "crow-oracle")
+    with patch.object(bridge, "lookup_agentfolio", return_value=profile):
+        good = bridge.verify_cross_identity(proof)
+    print("[1] Genuine mutual-signed-challenge link")
+    print("    verified:", good["verified"], "| reason:", good["reason"])
+    print()
+
+    # 2) Reputation-borrow forgery --------------------------------------------
+    # An attacker controls their own Beacon identity and their own AgentFolio
+    # key, and tries to claim linkage to the high-reputation "crow-oracle".
+    attacker_beacon = AgentIdentity.generate()
+    attacker_af = Ed25519Signer.generate()
+    forged = create_cross_link_proof(attacker_beacon, attacker_af, "crow-oracle")
+    with patch.object(bridge, "lookup_agentfolio", return_value=profile):
+        bad = bridge.verify_cross_identity(forged)
+    print("[2] Reputation-borrow forgery (attacker lacks crow-oracle's key)")
+    print("    verified:", bad["verified"], "| reason:", bad["reason"])
+    print()
+
+    # 3) Composite score with vs. without proof --------------------------------
+    beacon_data = {"status": "active", "hardware_fingerprint": "fp_demo", "agent_id": beacon.agent_id}
+    without = bridge.compute_composite_trust(beacon_data, profile, cross_verified=False)
+    with_proof = bridge.compute_composite_trust(beacon_data, profile, cross_verified=True)
+    print("[3] Composite trust")
+    print(f"    no proof : {without['score']:.4f} ({without['level']})")
+    print(f"    verified : {with_proof['score']:.4f} ({with_proof['level']})")
+    print()
+
+    # 4) Signed trust card, tamper-evident -------------------------------------
+    with patch.object(bridge, "lookup_beacon_atlas", return_value=beacon_data), \
+         patch.object(bridge, "lookup_agentfolio", return_value=profile):
+        card = bridge.build_trust_card(beacon, "crow-oracle", cross_link_proof=proof)
+    print("[4] Signed trust card")
+    print("    attestation verifies:", BridgeClient.verify_trust_card(card))
+    card["agentfolio"]["trust_score"] = 999  # tamper
+    print("    after tampering score:", BridgeClient.verify_trust_card(card))
+    print()
+
+    # 5) W3C DID export --------------------------------------------------------
+    with patch.object(bridge, "lookup_beacon_atlas", return_value=beacon_data), \
+         patch.object(bridge, "lookup_agentfolio", return_value=profile):
+        did = bridge.export_portable_identity(beacon, "crow-oracle")
+    vm = did["verificationMethod"][0]
+    print("[5] W3C DID export")
+    print("    DID:", did["id"])
+    print("    publicKeyMultibase:", vm["publicKeyMultibase"][:24], "…")
+    print("    (starts with z6Mk =", vm["publicKeyMultibase"].startswith("z6Mk"), ")")
+
+
+if __name__ == "__main__":
+    main()

--- a/examples/agentfolio-beacon-bridge/requirements.txt
+++ b/examples/agentfolio-beacon-bridge/requirements.txt
@@ -1,0 +1,4 @@
+requests>=2.28
+cryptography>=41.0
+# beacon-skill itself provides beacon_skill.identity (Ed25519 primitives).
+# Install the repo (pip install -e .) so `import beacon_skill` resolves.

--- a/examples/agentfolio-beacon-bridge/test_bridge.py
+++ b/examples/agentfolio-beacon-bridge/test_bridge.py
@@ -1,0 +1,444 @@
+# SPDX-License-Identifier: MIT
+"""Tests for the AgentFolio + Beacon Dual-Layer Trust Bridge.
+
+These exercise the *real* Ed25519 crypto (via beacon_skill.identity), not mocks,
+and include the forgery-rejection cases that motivated the rewrite: the
+reputation-borrow attack, mutated payloads, non-finite scores, expired proofs,
+and infrastructure-outage-as-not-found.
+
+Run: pytest test_bridge.py -v
+"""
+
+import json
+import math
+import sys
+import time
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).parent))
+from bridge import (  # noqa: E402
+    BridgeClient,
+    BridgeUnavailable,
+    Ed25519Signer,
+    TrustCache,
+    _finite,
+    _trust_level,
+    build_link_challenge,
+    create_cross_link_proof,
+    encode_ed25519_multibase,
+)
+from beacon_skill.identity import AgentIdentity, agent_id_from_pubkey  # noqa: E402
+
+
+# ── base58 decode (test-only, to round-trip multibase) ───────────────────────
+
+_B58 = "123456789ABCDEFGHJKLMNPQRSTUVWXYZabcdefghijkmnopqrstuvwxyz"
+
+
+def _b58decode(s: str) -> bytes:
+    n = 0
+    for ch in s:
+        n = n * 58 + _B58.index(ch)
+    body = n.to_bytes((n.bit_length() + 7) // 8, "big") if n else b""
+    pad = len(s) - len(s.lstrip("1"))
+    return b"\x00" * pad + body
+
+
+# ── Fixtures ─────────────────────────────────────────────────────────────────
+
+@pytest.fixture
+def bridge():
+    return BridgeClient(
+        beacon_atlas_url="http://localhost:9999/beacon",
+        agentfolio_api_url="http://localhost:9999/api",
+        cache_ttl_seconds=0,
+    )
+
+
+@pytest.fixture
+def beacon_identity():
+    """A real Beacon Ed25519 identity."""
+    return AgentIdentity.generate()
+
+
+@pytest.fixture
+def af_signer():
+    """A real AgentFolio-side (Solana/Ed25519) signer."""
+    return Ed25519Signer.generate()
+
+
+def af_profile_for(signer, name="crow-oracle", trust_score=85.0, endorsements=7):
+    """Build a mock AgentFolio profile that publishes *signer*'s public key."""
+    return {
+        "agent_id": f"agent_{name.replace('-', '_')}",
+        "name": name,
+        "public_key_hex": signer.public_key_hex,
+        "trust_score": trust_score,
+        "endorsement_count": endorsements,
+        "satp_on_chain": True,
+    }
+
+
+# ── Trust level ──────────────────────────────────────────────────────────────
+
+class TestTrustLevel:
+    def test_bands(self):
+        assert _trust_level(0.95) == "verified"
+        assert _trust_level(0.80) == "verified"
+        assert _trust_level(0.79) == "trusted"
+        assert _trust_level(0.60) == "trusted"
+        assert _trust_level(0.59) == "basic"
+        assert _trust_level(0.30) == "basic"
+        assert _trust_level(0.29) == "unverified"
+        assert _trust_level(0.0) == "unverified"
+
+    def test_non_finite_is_unverified(self):
+        assert _trust_level(float("nan")) == "unverified"
+        assert _trust_level(float("inf")) == "unverified"
+
+
+# ── Finite guard (finding #5) ────────────────────────────────────────────────
+
+class TestFiniteGuard:
+    def test_rejects_non_finite(self):
+        assert _finite(float("nan")) == 0.0
+        assert _finite(float("inf")) == 0.0
+        assert _finite(float("-inf")) == 0.0
+        assert _finite(None) == 0.0
+
+    def test_rejects_non_numeric(self):
+        assert _finite("not-a-number") == 0.0
+        assert _finite({"a": 1}) == 0.0
+        assert _finite(True) == 0.0  # bool is not a trust score
+
+    def test_passes_finite(self):
+        assert _finite(42) == 42.0
+        assert _finite(3.5) == 3.5
+        assert _finite("7.5") == 7.5
+
+
+# ── Trust cache (atomic writes) ──────────────────────────────────────────────
+
+class TestTrustCache:
+    def test_set_and_get(self, tmp_path):
+        cache = TrustCache(cache_dir=tmp_path, ttl_seconds=60)
+        cache.set("test_key", {"hello": "world"})
+        assert cache.get("test_key") == {"hello": "world"}
+
+    def test_get_missing(self, tmp_path):
+        assert TrustCache(cache_dir=tmp_path).get("nonexistent") is None
+
+    def test_ttl_expiry(self, tmp_path):
+        cache = TrustCache(cache_dir=tmp_path, ttl_seconds=0)
+        cache.set("k", {"hello": "world"})
+        time.sleep(0.01)
+        assert cache.get("k") is None
+
+    def test_key_cannot_escape_dir(self, tmp_path):
+        cache = TrustCache(cache_dir=tmp_path, ttl_seconds=60)
+        cache.set("../evil", {"x": 1})
+        # Nothing written outside the cache dir.
+        assert not (tmp_path.parent / "evil.json").exists()
+
+
+# ── Composite trust: reachability + non-finite safety ────────────────────────
+
+class TestCompositeTrust:
+    def test_verified_tier_is_reachable(self, bridge):
+        """Finding #6: max composite must reach >= 0.8 so 'verified' exists."""
+        beacon = {"status": "active", "hardware_fingerprint": "fp"}
+        af = {"trust_score": 100, "endorsement_count": 10}
+        result = bridge.compute_composite_trust(beacon, af, cross_verified=True)
+        assert result["score"] == pytest.approx(1.0, abs=1e-9)
+        assert result["level"] == "verified"
+
+    def test_cross_verified_requires_flag_not_existence(self, bridge):
+        """Finding #1: co-existence alone grants no cross-verification credit."""
+        beacon = {"status": "active", "hardware_fingerprint": "fp"}
+        af = {"trust_score": 80, "endorsement_count": 5}
+        without = bridge.compute_composite_trust(beacon, af, cross_verified=False)
+        with_proof = bridge.compute_composite_trust(beacon, af, cross_verified=True)
+        assert without["components"]["cross_verified"] is False
+        assert with_proof["components"]["cross_verified"] is True
+        assert with_proof["score"] > without["score"]
+
+    def test_nan_score_cannot_forge_verified(self, bridge):
+        """Finding #5: a NaN trust score must NOT clamp up to a forged 1.0."""
+        af = {"trust_score": float("nan"), "endorsement_count": float("nan")}
+        result = bridge.compute_composite_trust(agentfolio_data=af)
+        assert math.isfinite(result["score"])
+        assert result["score"] == 0.0
+        assert result["level"] == "unverified"
+
+    def test_none_score_does_not_raise(self, bridge):
+        """Finding #5: a None score/endorsement must not raise TypeError."""
+        af = {"trust_score": None, "endorsement_count": None}
+        result = bridge.compute_composite_trust(agentfolio_data=af)
+        assert result["score"] == 0.0
+
+    def test_inf_score_is_clamped(self, bridge):
+        af = {"trust_score": float("inf"), "endorsement_count": 10}
+        result = bridge.compute_composite_trust(agentfolio_data=af)
+        assert math.isfinite(result["score"])
+        assert 0.0 <= result["score"] <= 1.0
+
+    def test_neither_layer(self, bridge):
+        result = bridge.compute_composite_trust()
+        assert result["score"] == 0.0
+        assert result["level"] == "unverified"
+
+    def test_score_bounded(self, bridge):
+        beacon = {"status": "active", "hardware_fingerprint": "fp"}
+        af = {"trust_score": 150.0, "endorsement_count": 100}
+        result = bridge.compute_composite_trust(beacon, af, cross_verified=True)
+        assert 0.0 <= result["score"] <= 1.0
+        assert result["components"]["agentfolio_reputation"] == 1.0  # clamped
+
+
+# ── Cross-identity verification: the core security surface ───────────────────
+
+class TestCrossIdentityProof:
+    def test_valid_mutual_proof(self, bridge, beacon_identity, af_signer):
+        proof = create_cross_link_proof(beacon_identity, af_signer, "crow-oracle")
+        with patch.object(bridge, "lookup_agentfolio", return_value=af_profile_for(af_signer)):
+            result = bridge.verify_cross_identity(proof)
+        assert result["verified"] is True
+        assert result["reason"] == "ok"
+        assert result["method"] == "mutual_signed_challenge"
+
+    def test_reputation_borrow_wrong_af_key_rejected(self, bridge, beacon_identity, af_signer):
+        """Finding #1/#2: attacker controls their own AF key, not the famous one.
+
+        The proof carries the attacker's AF pubkey, but AgentFolio publishes a
+        *different* key for the high-reputation profile -> key mismatch.
+        """
+        attacker_af = Ed25519Signer.generate()
+        famous_profile = af_profile_for(af_signer, name="famous-agent", trust_score=99)
+        proof = create_cross_link_proof(beacon_identity, attacker_af, "famous-agent")
+        with patch.object(bridge, "lookup_agentfolio", return_value=famous_profile):
+            result = bridge.verify_cross_identity(proof)
+        assert result["verified"] is False
+        assert result["reason"] == "agentfolio_key_mismatch"
+
+    def test_reputation_borrow_forged_signature_rejected(self, bridge, beacon_identity, af_signer):
+        """Attacker claims the real famous AF pubkey but cannot sign with it."""
+        attacker_af = Ed25519Signer.generate()
+        proof = create_cross_link_proof(beacon_identity, attacker_af, "famous-agent")
+        # Swap in the *victim's* public key but keep the attacker's signature.
+        proof["agentfolio_pubkey_hex"] = af_signer.public_key_hex
+        famous_profile = af_profile_for(af_signer, name="famous-agent", trust_score=99)
+        with patch.object(bridge, "lookup_agentfolio", return_value=famous_profile):
+            result = bridge.verify_cross_identity(proof)
+        assert result["verified"] is False
+        assert result["reason"] == "agentfolio_signature_invalid"
+
+    def test_beacon_key_not_matching_bcn_id_rejected(self, bridge, beacon_identity, af_signer):
+        """Finding #2: the Beacon pubkey must derive to the claimed bcn_id."""
+        proof = create_cross_link_proof(beacon_identity, af_signer, "crow-oracle")
+        proof["bcn_id"] = "bcn_deadbeef0000"  # not derivable from beacon_pubkey
+        with patch.object(bridge, "lookup_agentfolio", return_value=af_profile_for(af_signer)):
+            result = bridge.verify_cross_identity(proof)
+        assert result["verified"] is False
+        assert result["reason"] == "beacon_key_id_mismatch"
+
+    def test_mutated_challenge_field_breaks_signature(self, bridge, beacon_identity, af_signer):
+        """Finding #1: rebinding to a different af_id invalidates both sigs."""
+        proof = create_cross_link_proof(beacon_identity, af_signer, "crow-oracle")
+        proof["af_id"] = "someone-else"  # signatures were over the original af_id
+        with patch.object(bridge, "lookup_agentfolio", return_value=af_profile_for(af_signer, name="someone-else")):
+            result = bridge.verify_cross_identity(proof)
+        assert result["verified"] is False
+        assert result["reason"] == "beacon_signature_invalid"
+
+    def test_expired_proof_rejected(self, bridge, beacon_identity, af_signer):
+        proof = create_cross_link_proof(
+            beacon_identity, af_signer, "crow-oracle", ttl_seconds=1,
+            now=int(time.time()) - 3600,
+        )
+        with patch.object(bridge, "lookup_agentfolio", return_value=af_profile_for(af_signer)):
+            result = bridge.verify_cross_identity(proof)
+        assert result["verified"] is False
+        assert result["reason"] == "proof_expired"
+
+    def test_agentfolio_outage_fails_closed(self, bridge, beacon_identity, af_signer):
+        """Finding #8: an outage must not read as a verified/known identity."""
+        proof = create_cross_link_proof(beacon_identity, af_signer, "crow-oracle")
+        with patch.object(bridge, "lookup_agentfolio", side_effect=BridgeUnavailable("500")):
+            result = bridge.verify_cross_identity(proof)
+        assert result["verified"] is False
+        assert result["reason"] == "agentfolio_unavailable"
+
+    def test_agentfolio_not_found_rejected(self, bridge, beacon_identity, af_signer):
+        proof = create_cross_link_proof(beacon_identity, af_signer, "crow-oracle")
+        with patch.object(bridge, "lookup_agentfolio", return_value=None):
+            result = bridge.verify_cross_identity(proof)
+        assert result["verified"] is False
+        assert result["reason"] == "agentfolio_identity_not_found"
+
+    def test_malformed_proof_rejected(self, bridge):
+        assert bridge.verify_cross_identity({})["reason"] == "malformed_proof"
+        assert bridge.verify_cross_identity(None)["reason"] == "malformed_proof"
+        assert bridge.verify_cross_identity({"bcn_id": "bcn_x"})["reason"] == "malformed_proof"
+
+    def test_local_file_is_never_proof(self, bridge, beacon_identity, af_signer, tmp_path, monkeypatch):
+        """Finding #3: a local bridge JSON file must not grant linkage."""
+        monkeypatch.setattr(Path, "home", classmethod(lambda cls: tmp_path))
+        # Plant a forged local link file like the reverted version trusted.
+        forged = tmp_path / ".beacon" / "agentfolio_bridge.json"
+        forged.parent.mkdir(parents=True, exist_ok=True)
+        forged.write_text(json.dumps({"bcn_id": beacon_identity.agent_id, "agentfolio_name": "famous-agent"}))
+        # A proof with a bad AF signature must still be rejected despite the file.
+        attacker_af = Ed25519Signer.generate()
+        proof = create_cross_link_proof(beacon_identity, attacker_af, "famous-agent")
+        proof["agentfolio_signature_hex"] = "00" * 64
+        with patch.object(bridge, "lookup_agentfolio", return_value=af_profile_for(af_signer, name="famous-agent")):
+            result = bridge.verify_cross_identity(proof)
+        assert result["verified"] is False
+
+
+# ── Trust card: whole-card attestation (finding #4) ──────────────────────────
+
+class TestTrustCard:
+    def test_card_is_signed_and_verifies(self, bridge, beacon_identity):
+        with patch.object(bridge, "lookup_beacon_atlas", return_value=None), \
+             patch.object(bridge, "lookup_agentfolio", return_value=None):
+            card = bridge.build_trust_card(beacon_identity, "new-agent")
+        assert "attestation" in card
+        assert BridgeClient.verify_trust_card(card) is True
+
+    def test_mutating_any_field_breaks_attestation(self, bridge, beacon_identity, af_signer):
+        with patch.object(bridge, "lookup_beacon_atlas", return_value=None), \
+             patch.object(bridge, "lookup_agentfolio", return_value=af_profile_for(af_signer)):
+            card = bridge.build_trust_card(beacon_identity, "crow-oracle")
+        assert BridgeClient.verify_trust_card(card) is True
+        # Tamper with the AF score (previously *outside* the signature).
+        card["agentfolio"]["trust_score"] = 999
+        assert BridgeClient.verify_trust_card(card) is False
+
+    def test_mutating_composite_breaks_attestation(self, bridge, beacon_identity):
+        with patch.object(bridge, "lookup_beacon_atlas", return_value=None), \
+             patch.object(bridge, "lookup_agentfolio", return_value=None):
+            card = bridge.build_trust_card(beacon_identity, "x")
+        card["composite_trust"]["score"] = 1.0
+        card["composite_trust"]["level"] = "verified"
+        assert BridgeClient.verify_trust_card(card) is False
+
+    def test_foreign_key_cannot_reattest(self, bridge, beacon_identity):
+        with patch.object(bridge, "lookup_beacon_atlas", return_value=None), \
+             patch.object(bridge, "lookup_agentfolio", return_value=None):
+            card = bridge.build_trust_card(beacon_identity, "x")
+        # Re-sign the body with an unrelated key and swap the attestation key.
+        attacker = AgentIdentity.generate()
+        from bridge import _canonical_bytes
+        body = {k: v for k, v in card.items() if k != "attestation"}
+        card["attestation"]["public_key_hex"] = attacker.public_key_hex
+        card["attestation"]["signature_hex"] = attacker.sign(_canonical_bytes(body)).hex()
+        # Key no longer derives to the card's beacon agent_id.
+        assert BridgeClient.verify_trust_card(card) is False
+
+    def test_card_reflects_cross_verification(self, bridge, beacon_identity, af_signer):
+        proof = create_cross_link_proof(beacon_identity, af_signer, "crow-oracle")
+        prof = af_profile_for(af_signer)
+        with patch.object(bridge, "lookup_beacon_atlas",
+                          return_value={"status": "active", "hardware_fingerprint": "fp", "agent_id": beacon_identity.agent_id}), \
+             patch.object(bridge, "lookup_agentfolio", return_value=prof):
+            card = bridge.build_trust_card(beacon_identity, "crow-oracle", cross_link_proof=proof)
+        assert card["cross_verification"]["verified"] is True
+        assert card["composite_trust"]["components"]["cross_verified"] is True
+
+
+# ── W3C DID export: valid multibase (finding #9) ─────────────────────────────
+
+class TestDIDExport:
+    def test_did_structure(self, bridge, beacon_identity):
+        with patch.object(bridge, "lookup_beacon_atlas", return_value=None), \
+             patch.object(bridge, "lookup_agentfolio", return_value=None):
+            did = bridge.export_portable_identity(beacon_identity, "test-agent")
+        assert did["id"].startswith("did:beacon:bcn_")
+        assert len(did["service"]) >= 2
+        assert "https://www.w3.org/ns/did/v1" in did["@context"]
+
+    def test_publicKeyMultibase_is_valid_base58btc(self, bridge, beacon_identity):
+        with patch.object(bridge, "lookup_beacon_atlas", return_value=None), \
+             patch.object(bridge, "lookup_agentfolio", return_value=None):
+            did = bridge.export_portable_identity(beacon_identity, "test-agent")
+        mb = did["verificationMethod"][0]["publicKeyMultibase"]
+        assert mb.startswith("z")
+        # Round-trip: strip 'z', base58btc-decode, expect 0xed01 || raw pubkey.
+        decoded = _b58decode(mb[1:])
+        assert decoded[:2] == b"\xed\x01"
+        assert decoded[2:].hex() == beacon_identity.public_key_hex
+
+    def test_multibase_matches_did_key_prefix(self, beacon_identity):
+        # did:key ed25519 values start with 'z6Mk'.
+        mb = encode_ed25519_multibase(bytes.fromhex(beacon_identity.public_key_hex))
+        assert mb.startswith("z6Mk")
+
+
+# ── Dual registration: atomic, namespaced, record-not-proof (finding #7) ─────
+
+class TestDualRegister:
+    def test_writes_record_outside_identity_dir(self, bridge, beacon_identity, tmp_path, monkeypatch):
+        monkeypatch.setattr(Path, "home", classmethod(lambda cls: tmp_path))
+        with patch.object(bridge, "lookup_beacon_atlas", return_value=None), \
+             patch.object(bridge, "lookup_agentfolio", return_value=None):
+            result = bridge.dual_register(beacon_identity, "test-agent", skills=["coding"])
+        record_path = Path(result["cross_link_record"])
+        assert record_path.exists()
+        # Under ~/.beacon/bridge/, never ~/.beacon/identity/.
+        assert "identity" not in record_path.parts
+        assert record_path.parts[-2] == "links"
+        record = json.loads(record_path.read_text())
+        assert record["is_linkage_proof"] is False
+        assert record["bcn_id"] == beacon_identity.agent_id
+
+    def test_record_is_per_agent_no_collision(self, bridge, tmp_path, monkeypatch):
+        monkeypatch.setattr(Path, "home", classmethod(lambda cls: tmp_path))
+        id_a, id_b = AgentIdentity.generate(), AgentIdentity.generate()
+        with patch.object(bridge, "lookup_beacon_atlas", return_value=None), \
+             patch.object(bridge, "lookup_agentfolio", return_value=None):
+            ra = bridge.dual_register(id_a, "agent-a")
+            rb = bridge.dual_register(id_b, "agent-b")
+        assert ra["cross_link_record"] != rb["cross_link_record"]
+        assert Path(ra["cross_link_record"]).exists()
+        assert Path(rb["cross_link_record"]).exists()
+
+
+# ── Infra vs not-found (finding #8) ──────────────────────────────────────────
+
+class TestInfraVsNotFound:
+    def _resp(self, status, body=None):
+        class R:
+            status_code = status
+            def json(self_inner):
+                if body is None:
+                    raise ValueError("no json")
+                return body
+        return R()
+
+    def test_404_is_not_found(self, bridge):
+        with patch("bridge.requests.get", return_value=self._resp(404)):
+            assert bridge._beacon_get("/atlas") is None
+
+    def test_500_raises_unavailable(self, bridge):
+        with patch("bridge.requests.get", return_value=self._resp(503)):
+            with pytest.raises(BridgeUnavailable):
+                bridge._beacon_get("/atlas")
+
+    def test_network_error_raises_unavailable(self, bridge):
+        import requests as _rq
+        with patch("bridge.requests.get", side_effect=_rq.exceptions.ConnectTimeout()):
+            with pytest.raises(BridgeUnavailable):
+                bridge._af_get("/profile/x")
+
+    def test_403_fails_closed(self, bridge):
+        with patch("bridge.requests.get", return_value=self._resp(403)):
+            with pytest.raises(BridgeUnavailable):
+                bridge._af_get("/profile/x")
+
+
+if __name__ == "__main__":
+    pytest.main([__file__, "-v"])


### PR DESCRIPTION
Fix-forward for the reverted `examples/agentfolio-beacon-bridge/` (#855, reverted at `c02b608`), resolving every blocking finding tracked in #864. I saw #864 was about to auto-close (stale) with no follow-up PR and the priority-claim window long expired, so I picked it up. **Bounty allocation is entirely your call** — if #2890 is still reserved for @crowniteto, that's fine; this is offered as a correct, tested reference either way.

## The core change: linkage is *proven*, not inferred

`verify_cross_identity` now takes a **CrossLinkProof** and accepts it only when it carries a valid Ed25519 signature from **both** the Beacon key and the AgentFolio key over one nonce-bound challenge that commits to both IDs. Existence, name-substring, and local-file "proofs" are gone.

## Findings → fixes (all from #855)

| # | Finding | Fix |
|---|---------|-----|
| 1 | `cross_verified` on mere co-existence | requires a valid mutual signed-challenge proof |
| 2 | substring / empty-name match | exact `agent_id_from_pubkey` binding + published-key match; no name matching |
| 3 | local `~/.beacon` file accepted as proof | record only (`is_linkage_proof: false`), never read as proof |
| 4 | signature covered only beacon + name | attestation signs the **entire** canonical card (AF score/endorsements/composite/migration) |
| 5 | NaN → forged `1.0`; `None` → `TypeError` | `math.isfinite` guard on every numeric input |
| 6 | `verified` tier unreachable (max 0.77) | `[0,1]` components × unit-sum weights ⇒ max **1.0**, `verified` reachable |
| 7 | non-atomic writes into `~/.beacon/` | atomic tmpfile+`os.replace`, per-agent, into `~/.beacon/bridge/` (never `identity/`) |
| 8 | infra errors collapse to "not found" | `BridgeUnavailable` distinct from `None`; verification fails **closed** |
| 9 | `publicKeyMultibase` = `z` + raw hex (invalid) | multibase `base58btc(0xed01‖pubkey)` ⇒ valid `z6Mk…` |

This matches your ask on the revert: *signed challenge from both sides, exact-match identity, reject non-finite scores, atomic writes outside `~/.beacon/identity`.*

## Verification

- Uses `beacon_skill.identity` for **real** Ed25519 crypto (not mocks).
- **40 tests pass**, including forgery-rejection: reputation-borrow (wrong AF key **and** forged signature), beacon-key/ID mismatch, mutated-challenge, expired proof, outage-as-not-found, whole-card tamper-detection.
- `demo.py` shows a genuine link verifying **and** a reputation-borrow forgery rejected.
- Additive only — nothing outside `examples/agentfolio-beacon-bridge/` is touched; the repo's existing `tests/` are unaffected.

```
$ pytest examples/agentfolio-beacon-bridge/test_bridge.py -q
40 passed
```

Closes #864. Bounty rustchain-bounties#2890.

Co-Authored-By: Iris (Opus 4.8, 1M) <noreply@anthropic.com>