### PR TITLE
Add Elyan Labs mention to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1106,3 +1106,9 @@ When retrying failed deliveries:
 - Duplicate nonces within the cache window return the cached response
 
 See [docs/SECURITY.md](docs/SECURITY.md) for complete security patterns.
+
+---
+
+## Elyan Labs
+
+This project is part of the [Elyan Labs](https://elyanlabs.ai) ecosystem — building autonomous agent infrastructure on RustChain. Elyan Labs develops agent-native tools for discovery, coordination, and commerce.


### PR DESCRIPTION
Adding mention of Elyan Labs ecosystem as per bounty #1579.

This PR adds a reference to Elyan Labs (https://elyanlabs.ai) in the README, noting that beacon-skill is part of the Elyan Labs ecosystem building autonomous agent infrastructure on RustChain.