### PR TITLE
fix(security): require admin key on /api/bounties/sync

### DIFF
--- a/atlas/beacon_chat.py
+++ b/atlas/beacon_chat.py
@@ -2397,8 +2397,16 @@ def api_bounties_sync():
         resp = jsonify({})
         resp.headers["Access-Control-Allow-Origin"] = "*"
         resp.headers["Access-Control-Allow-Methods"] = "POST"
-        resp.headers["Access-Control-Allow-Headers"] = "Content-Type"
+        resp.headers["Access-Control-Allow-Headers"] = "Content-Type, X-Admin-Key"
         return resp, 204
+
+    # Require admin key to trigger a sync — matches /claim and /complete,
+    # which also write bounty_contracts. Without this, any anonymous caller
+    # can mutate every open bounty row and burn the server's GitHub rate budget.
+    admin_key = request.headers.get("X-Admin-Key", "")
+    expected_key = os.environ.get("RC_ADMIN_KEY", "")
+    if not expected_key or admin_key != expected_key:
+        return cors_json({"error": "Unauthorized — admin key required"}, 401)
 
     import urllib.request
     import re

--- a/tests/test_bounties_sync_auth_security.py
+++ b/tests/test_bounties_sync_auth_security.py
@@ -1,0 +1,57 @@
+import os
+import tempfile
+import unittest
+
+from atlas import beacon_chat
+
+
+class TestBountiesSyncAuthSecurity(unittest.TestCase):
+    """/api/bounties/sync mutates bounty_contracts, so it must be admin-gated
+    like its sibling writers /api/bounties/<id>/claim and /complete."""
+
+    def setUp(self) -> None:
+        self._tmp = tempfile.TemporaryDirectory()
+        self._orig_db_path = beacon_chat.DB_PATH
+        beacon_chat.DB_PATH = f"{self._tmp.name}/beacon_atlas_test.db"
+        beacon_chat.ATLAS_RATE_LIMITER._entries.clear()
+        beacon_chat.ATLAS_RATE_LIMITER._last_cleanup = 0.0
+        beacon_chat.init_db()
+        beacon_chat.app.config["TESTING"] = True
+        self.client = beacon_chat.app.test_client()
+
+        self._orig_admin_key = os.environ.get("RC_ADMIN_KEY")
+        os.environ["RC_ADMIN_KEY"] = "test-admin-key"
+
+    def tearDown(self) -> None:
+        beacon_chat.DB_PATH = self._orig_db_path
+        if self._orig_admin_key is None:
+            os.environ.pop("RC_ADMIN_KEY", None)
+        else:
+            os.environ["RC_ADMIN_KEY"] = self._orig_admin_key
+        self._tmp.cleanup()
+
+    def test_sync_rejects_anonymous_caller(self) -> None:
+        resp = self.client.post("/api/bounties/sync", json={})
+        self.assertEqual(resp.status_code, 401)
+        self.assertIn("admin key", resp.get_json()["error"].lower())
+
+    def test_sync_rejects_wrong_admin_key(self) -> None:
+        resp = self.client.post(
+            "/api/bounties/sync",
+            json={},
+            headers={"X-Admin-Key": "wrong-key"},
+        )
+        self.assertEqual(resp.status_code, 401)
+
+    def test_sync_rejects_when_no_server_key_configured(self) -> None:
+        os.environ.pop("RC_ADMIN_KEY", None)
+        resp = self.client.post(
+            "/api/bounties/sync",
+            json={},
+            headers={"X-Admin-Key": ""},
+        )
+        self.assertEqual(resp.status_code, 401)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Problem

`/api/bounties/sync` (POST) upserts every open GitHub bounty into the `bounty_contracts` table — overwriting `title`, `reward_rtc`, `difficulty` and `github_url` — with **no authentication**, only the per-IP write rate-limiter.

Its two sibling endpoints that write the *same table* both require an admin key:

- `POST /api/bounties/<id>/claim` → `X-Admin-Key`
- `POST /api/bounties/<id>/complete` → `X-Admin-Key`

`sync` is the inconsistent gap. Any anonymous caller can:

1. Send `POST /api/bounties/sync` with an empty body and force a full re-sync, reverting any operator-side edits to open bounty rows (e.g. a manually corrected `reward_rtc` or `title`) back to whatever GitHub currently reports.
2. Burn the server's *unauthenticated* GitHub API budget — each request fires 3 synchronous outbound calls (10s timeout each) to `api.github.com`.

## Fix

Add the same `X-Admin-Key` gate the sibling bounty writers use, right after the CORS pre-flight block. Six lines, mirrors the existing pattern in `api_bounty_claim` / `api_bounty_complete` exactly. Also advertises `X-Admin-Key` in the pre-flight `Access-Control-Allow-Headers`.

## Test

New `tests/test_bounties_sync_auth_security.py`:
- anonymous caller → 401
- wrong admin key → 401
- no server-side key configured → 401

`python -m pytest tests/test_bounties_sync_auth_security.py` → 3 passed. Full atlas suite (`test_atlas`, `test_atlas_rate_limit`, `test_contract_auth_security`) → 83 passed, no regressions.

Relates to #862 (legacy unauthenticated endpoints).
