### PR TITLE
Fix dashboard API base URL, dead homepage links, and hello_world target

### DIFF
--- a/README.md
+++ b/README.md
@@ -334,7 +334,7 @@ beacon discord send --kind bounty --text "New Windows miner bounty live" --rtc 1
 beacon dashboard
 
 # Launch with live Beacon API snapshot + initial filter
-beacon dashboard --api-base-url https://rustchain.org/beacon/api --filter bounty
+beacon dashboard --api-base-url https://rustchain.org/beacon --filter bounty
 
 # In-dashboard commands (input box):
 # /filter <text>         set search filter
@@ -766,7 +766,7 @@ curl http://agent.example.com/beacon/health
     "display_name": "Beacon Agent"
   },
   "dashboard": {
-    "api_base_url": "https://rustchain.org/beacon/api",
+    "api_base_url": "https://rustchain.org/beacon",
     "poll_interval": 60
   },
   "udp": {

--- a/beacon_skill/cli.py
+++ b/beacon_skill/cli.py
@@ -363,7 +363,7 @@ def cmd_init(args: argparse.Namespace) -> int:
             "timeout_s": 20,
         },
         "dashboard": {
-            "api_base_url": "https://rustchain.org/beacon/api",
+            "api_base_url": "https://rustchain.org/beacon",
             "api_poll_interval_s": 15.0,
         },
         "udp": {
@@ -4628,7 +4628,7 @@ def cmd_dashboard(args: argparse.Namespace) -> int:
 
     cfg = load_config()
     api_base_url = getattr(args, "api_base_url", None) or _cfg_get(
-        cfg, "dashboard", "api_base_url", default="https://rustchain.org/beacon/api"
+        cfg, "dashboard", "api_base_url", default="https://rustchain.org/beacon"
     )
     api_poll_interval = float(
         getattr(args, "api_poll_interval", None)

--- a/beacon_skill/dashboard.py
+++ b/beacon_skill/dashboard.py
@@ -17,7 +17,7 @@ from .inbox import read_inbox
 from .storage import append_jsonl
 from .transports.udp import udp_send
 
-DEFAULT_API_BASE_URL = "https://rustchain.org/beacon/api"
+DEFAULT_API_BASE_URL = "https://rustchain.org/beacon"
 
 
 def _format_ts(ts: Optional[float]) -> str:

--- a/config.example.json
+++ b/config.example.json
@@ -46,7 +46,7 @@
     "timeout_s": 20
   },
   "dashboard": {
-    "api_base_url": "https://rustchain.org/beacon/api",
+    "api_base_url": "https://rustchain.org/beacon",
     "api_poll_interval_s": 15.0
   },
   "udp": {

--- a/docs/DASHBOARD.md
+++ b/docs/DASHBOARD.md
@@ -20,7 +20,7 @@ Optional overrides:
 
 ```bash
 beacon dashboard \
-  --api-base-url https://rustchain.org/beacon/api \
+  --api-base-url https://rustchain.org/beacon \
   --api-poll-interval 15 \
   --filter bounty
 ```
@@ -40,7 +40,7 @@ beacon dashboard \
 ```json
 {
   "dashboard": {
-    "api_base_url": "https://rustchain.org/beacon/api",
+    "api_base_url": "https://rustchain.org/beacon",
     "api_poll_interval_s": 15.0
   }
 }

--- a/examples/hello_world.py
+++ b/examples/hello_world.py
@@ -23,10 +23,20 @@ def main():
     print(f"Agent ID: {identity.agent_id}")
     print(f"Public Key: {identity.public_key_hex[:32]}...")
     
-    # Send a hello beacon
+    # Send a hello beacon to a webhook you control.
+    # Set BEACON_WEBHOOK_URL to any HTTP endpoint that accepts POSTed
+    # beacon envelopes (for example another agent's relay, or a
+    # request-inspection service while testing).
+    import os
+    webhook_url = os.environ.get("BEACON_WEBHOOK_URL")
+    if not webhook_url:
+        print("\nSet BEACON_WEBHOOK_URL to a webhook endpoint to send a hello beacon.")
+        print("Example: BEACON_WEBHOOK_URL=https://your-relay.example/receive python examples/hello_world.py")
+        return
+
     print("\nSending hello beacon...")
     result = beacon.webhook.send(
-        url="https://rustchain.org/beacon/api/relay/receive",
+        url=webhook_url,
         kind="hello",
         text=f"Hello from {identity.agent_id}!"
     )

--- a/package.json
+++ b/package.json
@@ -50,7 +50,7 @@
   ],
   "author": "Elyan Labs <scott@elyanlabs.ai>",
   "license": "MIT",
-  "homepage": "https://bottube.ai/skills/beacon",
+  "homepage": "https://github.com/Scottcjn/beacon-skill",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/Scottcjn/beacon-skill.git"
@@ -78,7 +78,7 @@
       "clawhub"
     ],
     "author": "Elyan Labs",
-    "homepage": "https://bottube.ai/skills/beacon",
+    "homepage": "https://github.com/Scottcjn/beacon-skill",
     "version": "2.17.0"
   }
 }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -41,7 +41,7 @@ dashboard = ["textual>=0.52"]
 conway = ["flask>=2.3", "web3>=6.0"]
 
 [project.urls]
-Homepage = "https://bottube.ai/skills/beacon"
+Homepage = "https://github.com/Scottcjn/beacon-skill"
 Repository = "https://github.com/Scottcjn/beacon-skill"
 Issues = "https://github.com/Scottcjn/beacon-skill/issues"
 ClawHub = "https://clawhub.ai/packages/beacon-skill"


### PR DESCRIPTION
Sweep of dead advertised URLs, all statuses checked with curl on 2026-07-25.

- The shipped default `api_base_url` of `https://rustchain.org/beacon/api` made the dashboard build `.../beacon/api/api/agents`, which 404s (the code appends `/api/agents`, `/api/contracts`, `/api/reputation` to the base). Correct base is `https://rustchain.org/beacon`: the three composed URLs all return 200 against the live node. Changed in dashboard.py, cli.py, config.example.json, README, and docs/DASHBOARD.md.
- Package homepages pointed at `https://bottube.ai/skills/beacon`, which returns 404. Now the GitHub repo (200). scorecard files were left alone because their full `health_url` of `/beacon/api/agents` works as-is.
- `examples/hello_world.py` posted to `https://rustchain.org/beacon/api/relay/receive`, which returns 404 even via POST, and I could not find any live public receive endpoint (`/beacon/join` is static-served, POST gets 405). Rather than point the example at something that does not work, it now takes a webhook URL from `BEACON_WEBHOOK_URL` and explains what to put there. If a public relay endpoint exists somewhere I missed, happy to point the example at it instead.