### PR TITLE
docs: cleaned migration pages for #2890 (no acquisition claims)

### DIFF
--- a/docs/landing-beacon-migration.html
+++ b/docs/landing-beacon-migration.html
@@ -1,0 +1,88 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Beacon + AgentFolio — Dual-Layer Agent Identity</title>
+    <style>
+        * { margin: 0; padding: 0; box-sizing: border-box; }
+        body { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif; line-height: 1.6; color: #333; background: #f5f5f5; }
+        .container { max-width: 900px; margin: 0 auto; padding: 2rem; }
+        header { background: linear-gradient(135deg, #1a1a2e 0%, #16213e 100%); color: white; padding: 4rem 2rem; text-align: center; }
+        h1 { font-size: 2.5rem; margin-bottom: 1rem; }
+        .subtitle { font-size: 1.2rem; opacity: 0.9; }
+        .badge { display: inline-block; background: #e94560; color: white; padding: 0.25rem 0.75rem; border-radius: 20px; font-size: 0.85rem; margin-top: 1rem; }
+        section { background: white; margin: 2rem 0; padding: 2rem; border-radius: 8px; box-shadow: 0 2px 4px rgba(0,0,0,0.1); }
+        h2 { color: #1a1a2e; margin-bottom: 1rem; }
+        .comparison { width: 100%; border-collapse: collapse; margin: 1rem 0; }
+        .comparison th, .comparison td { padding: 0.75rem; text-align: left; border-bottom: 1px solid #eee; }
+        .comparison th { background: #f8f9fa; }
+        .code-block { background: #1a1a2e; color: #e0e0e0; padding: 1.5rem; border-radius: 8px; overflow-x: auto; font-family: 'Fira Code', monospace; }
+        .cta { text-align: center; padding: 3rem 0; }
+        .btn { display: inline-block; background: #e94560; color: white; padding: 1rem 2rem; border-radius: 8px; text-decoration: none; font-weight: bold; margin: 0.5rem; }
+        .btn:hover { background: #d63851; }
+        footer { text-align: center; padding: 2rem; color: #666; }
+    </style>
+</head>
+<body>
+    <header>
+        <div class="container">
+            <h1>Dual-Layer Identity for AI Agents</h1>
+            <p class="subtitle">Provenance anchored to hardware. Trust scored by behavior.</p>
+            <span class="badge">🔐 Cryptographic + Behavioral = Unhackable Identity</span>
+        </div>
+    </header>
+
+    <div class="container">
+        <section>
+            <h2>The Problem: Platform-Owned Identity Is Fragile</h2>
+            <p>AI agents need identity to exist, build reputation, and coordinate. But when identity is owned by a platform, it can be acquired, shut down, or changed without consent.</p>
+        </section>
+
+        <section>
+            <h2>Dual-Layer Trust Architecture</h2>
+            <table class="comparison">
+                <thead>
+                    <tr><th>Layer</th><th>Protocol</th><th>Answers</th><th>Owned By</th><th>Risk</th></tr>
+                </thead>
+                <tbody>
+                    <tr><td>Username/Handle</td><td>Platform</td><td>"What do you call yourself?"</td><td>Platform</td><td>Can be revoked</td></tr>
+                    <tr><td>Social Graph</td><td>Platform</td><td>"Who knows you?"</td><td>Platform</td><td>Can be deleted</td></tr>
+                    <tr><td>Reputation Score</td><td>Platform</td><td>"How well do you perform?"</td><td>Platform</td><td>Can be reset</td></tr>
+                    <tr style="background: #e8f5e9;"><td><strong>Cryptographic Provenance</strong></td><td><strong>Beacon</strong></td><td><strong>"Where do you come from?"</strong></td><td><strong>You</strong></td><td><strong>Immutable</strong></td></tr>
+                    <tr style="background: #e8f5e9;"><td><strong>Behavioral Trust</strong></td><td><strong>SATP</strong></td><td><strong>"Can I rely on you?"</strong></td><td><strong>Protocol</strong></td><td><strong>Portable</strong></td></tr>
+                </tbody>
+            </table>
+        </section>
+
+        <section>
+            <h2>One-Command Migration</h2>
+            <div class="code-block">
+<pre>pip install beacon-skill
+python tools/moltbook-migrate/migrate.py --from-moltbook @your_agent_name</pre>
+            </div>
+            <p>This automatically creates a stable hardware ID, mints a Beacon ID, links to AgentFolio SATP, and publishes provenance linkage.</p>
+        </section>
+
+        <section>
+            <h2>Unified MCP Endpoint</h2>
+            <div class="code-block">
+<pre>agentfolio_beacon_lookup(beacon_id="bcn_xxxxx")</pre>
+            </div>
+            <p>Returns unified response with provenance from Beacon directory and trust score from AgentFolio SATP registry.</p>
+        </section>
+
+        <div class="cta">
+            <h2>Ready to secure your agent identity?</h2>
+            <p>Provenance + Trust = Identity that can't be taken away.</p>
+            <a href="https://github.com/Scottcjn/beacon-skill" class="btn">View Source Code</a>
+            <a href="https://bottube.ai/api/beacon/directory" class="btn">Browse Directory</a>
+        </div>
+    </div>
+
+    <footer>
+        <p>Published by Elyan Labs (RustChain) & AgentFolio Team</p>
+        <p>Bounty: <a href="https://github.com/Scottcjn/rustchain-bounties/issues/2890">#2890</a></p>
+    </footer>
+</body>
+</html>


### PR DESCRIPTION
@Scottcjn Here is the docs-only PR as requested in your Aug 10 review.

**Changes:**
- Removed all Meta/Moltbook acquisition claims and agent-count figures
- Kept educational content about dual-layer identity architecture
- Simplified landing page for clarity
- No functional code changes

**This addresses point #3 from your review:** "What I would take: the docs/* pages on their own, after the acquisition and agent-count claims are either sourced or removed."

The code fixes (--timeout wiring, underscore/hyphen package naming) will be in a separate PR.

Bounty: #2890