### PR TITLE
fix(atlas): trust forwarded IPs only from configured proxies

### DIFF
--- a/atlas/beacon_chat.py
+++ b/atlas/beacon_chat.py
@@ -9,6 +9,7 @@ Runs on port 8071 behind nginx.
 
 import hashlib
 import html
+import ipaddress
 from urllib.parse import quote as _urlquote
 import os
 import secrets
@@ -58,6 +59,7 @@ RELAY_PING_NONCE_WINDOW_S = 300     # Max clock skew + replay window
 RELAY_PING_NONCE_MAX_LEN = 128      # Bound nonce payload size
 RELAY_SEO_DESCRIPTION_MAX_LEN = 500
 RELAY_SEO_URL_MAX_LEN = 512
+TRUSTED_PROXY_CIDRS = os.environ.get("ATLAS_TRUSTED_PROXIES", "127.0.0.1,::1")
 
 KNOWN_PROVIDERS = {
     "xai": "xAI (Grok)",
@@ -85,9 +87,75 @@ BANNED_NAME_PATTERNS = [
 ]
 
 
+def _configured_trusted_proxy_networks():
+    """Return configured proxy CIDRs that may supply forwarding headers."""
+    raw = app.config.get("TRUSTED_PROXY_CIDRS", TRUSTED_PROXY_CIDRS)
+    if isinstance(raw, str):
+        entries = [part.strip() for part in raw.split(",")]
+    else:
+        entries = [str(part).strip() for part in (raw or [])]
+
+    networks = []
+    for entry in entries:
+        if not entry:
+            continue
+        try:
+            networks.append(ipaddress.ip_network(entry, strict=False))
+        except ValueError:
+            app.logger.warning("Ignoring invalid trusted proxy CIDR: %s", entry)
+    return tuple(networks)
+
+
+def _parse_ip_literal(value):
+    try:
+        return ipaddress.ip_address(str(value or "").strip())
+    except ValueError:
+        return None
+
+
+def _ip_in_networks(ip, networks):
+    return any(ip in network for network in networks)
+
+
+def _forwarded_for_client_ip(header_value, trusted_networks):
+    """Pick the proxy-appended client IP from an X-Forwarded-For chain.
+
+    Nginx's ``$proxy_add_x_forwarded_for`` appends the direct client address to
+    any client-supplied left side of the chain. Walking from the right prevents
+    a caller from choosing the rate-limit key by pre-seeding extra leftmost
+    values.
+    """
+    chain = []
+    for part in (header_value or "").split(","):
+        ip = _parse_ip_literal(part)
+        if ip is not None:
+            chain.append(ip)
+    for ip in reversed(chain):
+        if not _ip_in_networks(ip, trusted_networks):
+            return str(ip)
+    return None
+
+
 def get_real_ip():
-    """Get real client IP from proxy headers, falling back to remote_addr."""
-    return request.headers.get("X-Real-IP") or request.headers.get("X-Forwarded-For", "").split(",")[0].strip() or request.remote_addr
+    """Get a normalized client IP without trusting spoofable headers directly."""
+    remote_addr = request.remote_addr or ""
+    trusted_networks = _configured_trusted_proxy_networks()
+    remote_ip = _parse_ip_literal(remote_addr)
+    if remote_ip is None or not _ip_in_networks(remote_ip, trusted_networks):
+        return remote_addr
+
+    forwarded_client = _forwarded_for_client_ip(
+        request.headers.get("X-Forwarded-For", ""),
+        trusted_networks,
+    )
+    if forwarded_client:
+        return forwarded_client
+
+    real_ip = _parse_ip_literal(request.headers.get("X-Real-IP", ""))
+    if real_ip is not None and not _ip_in_networks(real_ip, trusted_networks):
+        return str(real_ip)
+
+    return remote_addr
 
 def dns_resolve(name_or_id):
     """Resolve a human-readable name to a beacon agent_id via DNS table.
@@ -3065,7 +3133,7 @@ def _agent_profile_html(agent, caps, dns_names, profile=None, matches=None):
         for match in matches[:4]:
             match_items.append(
                 "<li>"
-                f"<strong><a href=\"/beacon/agent/{_urlquote(str(match['agent_id']), safe="")}\">{html.escape(str(match['name']))}</a></strong> "
+                f"<strong><a href=\"/beacon/agent/{_urlquote(str(match['agent_id']), safe='')}\">{html.escape(str(match['name']))}</a></strong> "
                 f"({html.escape(str(match['provider_name']))}) — score {match['score']:.1f}"
                 f"<br><span class=\"meta\">{html.escape(' · '.join(str(r) for r in match['reasons'][:3]))}</span>"
                 "</li>"

--- a/tests/test_atlas_rate_limit.py
+++ b/tests/test_atlas_rate_limit.py
@@ -15,6 +15,7 @@ def setup_function():
     beacon_chat.ATLAS_RATE_LIMITER._last_cleanup = 0.0
     beacon_chat.app.config["RATE_LIMIT_READ_PER_MIN"] = beacon_chat.READ_LIMIT_PER_MIN
     beacon_chat.app.config["RATE_LIMIT_WRITE_PER_MIN"] = beacon_chat.WRITE_LIMIT_PER_MIN
+    beacon_chat.app.config["TRUSTED_PROXY_CIDRS"] = "127.0.0.1,::1"
 
     # Ensure bounty table exists for endpoint tests in fresh DBs.
     conn = sqlite3.connect(beacon_chat.DB_PATH)
@@ -122,6 +123,75 @@ def test_api_health_read_rate_limit():
 
     assert r1.status_code == 200
     assert r2.status_code == 429
+
+
+def test_get_real_ip_ignores_forwarded_headers_from_untrusted_client():
+    beacon_chat.app.config["TRUSTED_PROXY_CIDRS"] = "127.0.0.1"
+
+    with beacon_chat.app.test_request_context(
+        "/api/health",
+        headers={
+            "X-Real-IP": "203.0.113.10",
+            "X-Forwarded-For": "198.51.100.9, 203.0.113.11",
+        },
+        environ_overrides={"REMOTE_ADDR": "10.77.77.77"},
+    ):
+        assert beacon_chat.get_real_ip() == "10.77.77.77"
+
+
+def test_get_real_ip_uses_proxy_appended_forwarded_for_from_trusted_proxy():
+    beacon_chat.app.config["TRUSTED_PROXY_CIDRS"] = "127.0.0.1"
+
+    with beacon_chat.app.test_request_context(
+        "/api/health",
+        headers={"X-Forwarded-For": "198.51.100.200, 203.0.113.25"},
+        environ_overrides={"REMOTE_ADDR": "127.0.0.1"},
+    ):
+        assert beacon_chat.get_real_ip() == "203.0.113.25"
+
+
+def test_direct_header_spoofing_cannot_bypass_read_rate_limit():
+    beacon_chat.app.config["TESTING"] = True
+    beacon_chat.app.config["RATE_LIMIT_READ_PER_MIN"] = 1
+    beacon_chat.app.config["TRUSTED_PROXY_CIDRS"] = "127.0.0.1"
+
+    client = beacon_chat.app.test_client()
+    r1 = client.get(
+        "/api/health",
+        headers={"X-Real-IP": "203.0.113.10"},
+        environ_overrides={"REMOTE_ADDR": "10.88.88.88"},
+    )
+    r2 = client.get(
+        "/api/health",
+        headers={"X-Real-IP": "203.0.113.11"},
+        environ_overrides={"REMOTE_ADDR": "10.88.88.88"},
+    )
+
+    assert r1.status_code == 200
+    assert r2.status_code == 429
+    assert "api_read:10.88.88.88" in beacon_chat.ATLAS_RATE_LIMITER._entries
+
+
+def test_leftmost_forwarded_for_spoofing_cannot_bypass_read_rate_limit():
+    beacon_chat.app.config["TESTING"] = True
+    beacon_chat.app.config["RATE_LIMIT_READ_PER_MIN"] = 1
+    beacon_chat.app.config["TRUSTED_PROXY_CIDRS"] = "127.0.0.1"
+
+    client = beacon_chat.app.test_client()
+    r1 = client.get(
+        "/api/health",
+        headers={"X-Forwarded-For": "198.51.100.200, 203.0.113.25"},
+        environ_overrides={"REMOTE_ADDR": "127.0.0.1"},
+    )
+    r2 = client.get(
+        "/api/health",
+        headers={"X-Forwarded-For": "198.51.100.201, 203.0.113.25"},
+        environ_overrides={"REMOTE_ADDR": "127.0.0.1"},
+    )
+
+    assert r1.status_code == 200
+    assert r2.status_code == 429
+    assert "api_read:203.0.113.25" in beacon_chat.ATLAS_RATE_LIMITER._entries
 
 
 def test_api_write_limit_is_per_ip():


### PR DESCRIPTION
## Summary

This PR fixes the remaining M1 rate-limit bypass documented in #862: `get_real_ip()` trusted `X-Real-IP` and the leftmost `X-Forwarded-For` value even when the request did not come from a trusted reverse proxy.

It also fixes a current import blocker in `atlas/beacon_chat.py`: the collaborator profile link f-string used `safe=""` inside a double-quoted f-string expression, so the module raised `SyntaxError: f-string: unmatched '('` before tests could import it.

## Vulnerability / reproduction

Before this patch, a direct client could rotate spoofed forwarding headers and get separate rate-limit buckets while using the same TCP peer address:

```text
direct spoof status codes: 200 200
rate-limit keys: ['api_read:203.0.113.10', 'api_read:203.0.113.11']
```

That means the process-local API read/write limit could be bypassed by changing a header unless nginx happened to overwrite it correctly.

## Fix

- Add `ATLAS_TRUSTED_PROXIES` / `app.config["TRUSTED_PROXY_CIDRS"]` with a fail-closed default of loopback only (`127.0.0.1,::1`).
- Ignore `X-Real-IP` and `X-Forwarded-For` unless `request.remote_addr` is inside the trusted proxy CIDR set.
- For `X-Forwarded-For`, walk the chain from right to left and pick the first untrusted address, so client-supplied leftmost spoof values cannot choose the rate-limit key when nginx appends the real peer address.
- Keep rate-limit logs and buckets on the same normalized client IP returned by `get_real_ip()`.

## Tests

```text
uv run --no-project --with pytest --with flask --with requests --with cryptography --with pynacl python -m pytest -q tests\test_atlas_rate_limit.py
# 11 passed, 1 warning

uv run --no-project --with pytest --with flask --with requests --with cryptography --with pynacl python -m pytest -q tests\test_atlas_rate_limit.py tests\test_relay_register_security.py tests\test_relay_message_security.py tests\test_collaborator_matcher.py tests\test_revocation_rotation.py
# 33 passed, 1 warning

uv run --no-project --with flask --with requests --with cryptography --with pynacl python -m py_compile atlas\beacon_chat.py tests\test_atlas_rate_limit.py
# passed

git diff --check
# passed (Windows CRLF warnings only)
```

Partially addresses #862 (M1). L1 mnemonic hardening remains separate.

## Payout metadata

Wallet/miner id / payout alias: `L1nkinPark`
Native RTC payout address: `RTC973498f72747cd1637e395521319c0ad61c0f68c`
Native RTC public key: `ee2b512bf5a18951c328282c07848e76aa9945c35cd56b229e90793dfe069e4c`
Wallet registration/update: https://github.com/Scottcjn/rustchain-bounties/issues/16647#issuecomment-5446887073