### PR TITLE
fix(identity): derive mnemonic keys with BIP39 PBKDF2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,7 @@ This window covers ~161 commits since `v2.16.0` (2026-03-08). Highlights:
 - **ClawNews v0.1 surface** — first cut of `beacon clawnews` commands plus 15 unit tests for the validation functions in `clawnews_enhanced`. Foundation for the news-distribution transport rollout.
 
 ### Security
+- **Mnemonic restore compatibility guard** — `beacon identity restore` now has an explicit `--legacy` path for pre-BIP39 raw-SHA256 mnemonic identities, plus `--expect-agent-id` to refuse accidental derivation mismatches. The long-running Gemini SEO relay agent is pinned to legacy derivation so this KDF hardening does not silently rotate its production `agent_id`.
 - **Reject unauthenticated relay registration via heartbeat** ([#843](https://github.com/Scottcjn/beacon-skill/pull/843), fixes [#830](https://github.com/Scottcjn/beacon-skill/issues/830)) — before this fix, `/relay/heartbeat` would auto-register an arbitrary `agent_id` for any caller with any Bearer token, returning a valid `relay_token`. That's identity spoofing wearing a heartbeat costume. The fix requires explicit prior registration before heartbeats can mint relay tokens. **All operators should update.**
 - **Hardcoded `verify=False` SSL paths removed** ([#827](https://github.com/Scottcjn/beacon-skill/issues/827), [#846](https://github.com/Scottcjn/beacon-skill/pull/846)) — SSL verification is now on by default everywhere. The opt-out is environment-variable controlled (`BEACON_VERIFY_SSL=0`) for lab use, not silently off in production code.
 

--- a/README.md
+++ b/README.md
@@ -166,12 +166,22 @@ beacon identity new --mnemonic
 # Password-protect your keystore
 beacon identity new --password
 
-# Restore from seed phrase
+# Restore a modern BIP39 seed phrase
 beacon identity restore "word1 word2 word3 ... word24"
+
+# Restore a pre-BIP39 Beacon mnemonic without rotating the old agent_id
+beacon identity restore --legacy "word1 word2 word3 ... word24"
+
+# If you know the expected agent_id, make restore refuse the wrong derivation
+beacon identity restore --expect-agent-id bcn_a1b2c3d4e5f6 "word1 word2 word3 ... word24"
 
 # Trust another agent's public key
 beacon identity trust bcn_a1b2c3d4e5f6 <pubkey_hex>
 ```
+
+Mnemonic restores now default to BIP39 PBKDF2-HMAC-SHA512. Existing identities
+created by older Beacon releases used a raw-SHA256 derivation; restore them with
+`--legacy` (or `--expect-agent-id`) so the recovered `agent_id` does not change.
 
 Agent IDs use the format `bcn_` + first 12 hex of SHA256(pubkey) = 16 chars total.
 

--- a/atlas/gemini_seo_agent.py
+++ b/atlas/gemini_seo_agent.py
@@ -136,7 +136,9 @@ def _save_state(state: Dict):
 
 def register_on_relay():
     """Register the Gemini SEO agent on the Beacon relay."""
-    identity = AgentIdentity.from_mnemonic(f"gemini-seo-agent-{AGENT_NAME}")
+    # This production relay identity predates BIP39 mnemonic stretching and is
+    # intentionally pinned so a dependency update does not rotate its agent_id.
+    identity = AgentIdentity.from_legacy_mnemonic(f"gemini-seo-agent-{AGENT_NAME}")
     reg_payload = json.dumps({
         "model_id": GEMINI_MODEL,
         "provider": AGENT_PROVIDER,
@@ -178,7 +180,8 @@ def heartbeat():
     state = _load_state()
     token = state.get("relay_token")
     agent_id = state.get("agent_id")
-    identity = AgentIdentity.from_mnemonic(f"gemini-seo-agent-{AGENT_NAME}")
+    # Keep the same legacy relay identity used during registration.
+    identity = AgentIdentity.from_legacy_mnemonic(f"gemini-seo-agent-{AGENT_NAME}")
 
     if not token or not agent_id:
         print("Not registered. Run: gemini_seo_agent.py register")

--- a/beacon_skill/cli.py
+++ b/beacon_skill/cli.py
@@ -472,12 +472,71 @@ def cmd_identity_restore(args: argparse.Namespace) -> int:
     from .identity import AgentIdentity
     phrase = args.mnemonic_phrase
     password = getattr(args, "password", None)
-    ident = AgentIdentity.from_mnemonic(phrase)
+    legacy = bool(getattr(args, "legacy", False))
+    expected_agent_id = (getattr(args, "expect_agent_id", None) or "").strip()
+
+    modern_ident = AgentIdentity.from_mnemonic(phrase)
+    legacy_ident = AgentIdentity.from_legacy_mnemonic(phrase)
+    derivation = "bip39_pbkdf2_sha512"
+    ident = modern_ident
+
+    if legacy:
+        ident = legacy_ident
+        derivation = "legacy_sha256"
+        print(
+            "warning: restoring a pre-BIP39 Beacon mnemonic with raw SHA256; "
+            "new identities should omit --legacy.",
+            file=sys.stderr,
+        )
+    elif expected_agent_id:
+        if expected_agent_id == modern_ident.agent_id:
+            ident = modern_ident
+        elif expected_agent_id == legacy_ident.agent_id:
+            ident = legacy_ident
+            derivation = "legacy_sha256"
+            print(
+                "warning: --expect-agent-id matched the legacy SHA256 mnemonic "
+                "derivation; use --legacy for future restores.",
+                file=sys.stderr,
+            )
+        else:
+            print(json.dumps({
+                "error": "Mnemonic does not restore to the expected agent ID",
+                "expected_agent_id": expected_agent_id,
+                "bip39_agent_id": modern_ident.agent_id,
+                "legacy_agent_id": legacy_ident.agent_id,
+            }, indent=2), file=sys.stderr)
+            return 1
+    else:
+        try:
+            existing_ident = AgentIdentity.load(password=password)
+        except (FileNotFoundError, ValueError):
+            existing_ident = None
+        if existing_ident and existing_ident.agent_id == legacy_ident.agent_id:
+            ident = legacy_ident
+            derivation = "legacy_sha256"
+            print(
+                "warning: existing keystore matches the legacy SHA256 mnemonic "
+                "derivation, so restore kept the legacy agent_id. Use --legacy "
+                "when restoring this identity on a new machine.",
+                file=sys.stderr,
+            )
+
+    if expected_agent_id and ident.agent_id != expected_agent_id:
+        print(json.dumps({
+            "error": "Mnemonic does not restore to the expected agent ID",
+            "expected_agent_id": expected_agent_id,
+            "selected_agent_id": ident.agent_id,
+            "derivation": derivation,
+        }, indent=2), file=sys.stderr)
+        return 1
+
     path = ident.save(password=password)
     print(json.dumps({
         "agent_id": ident.agent_id,
         "public_key_hex": ident.public_key_hex,
         "keystore": str(path),
+        "derivation": derivation,
         "restored": True,
     }, indent=2))
     return 0
@@ -4701,6 +4760,16 @@ def main(argv: Optional[List[str]] = None) -> None:
     sp = ident_sub.add_parser("restore", help="Restore identity from a mnemonic seed phrase")
     sp.add_argument("mnemonic_phrase", help='24-word mnemonic (quoted string, e.g. "word1 word2 ...")')
     sp.add_argument("--password", default=None, help="Encrypt the restored keystore")
+    sp.add_argument(
+        "--legacy",
+        action="store_true",
+        help="Restore a pre-BIP39 Beacon mnemonic using the legacy SHA256 derivation",
+    )
+    sp.add_argument(
+        "--expect-agent-id",
+        default=None,
+        help="Abort unless the restored mnemonic matches this agent ID; auto-selects legacy if needed",
+    )
     sp.set_defaults(func=cmd_identity_restore)
 
     sp = ident_sub.add_parser("trust", help="Trust an agent's public key")

--- a/beacon_skill/identity.py
+++ b/beacon_skill/identity.py
@@ -4,6 +4,7 @@ import hashlib
 import json
 import os
 import secrets
+import unicodedata
 from pathlib import Path
 from typing import Any, Dict, Optional, Tuple
 
@@ -26,6 +27,36 @@ AGENT_ID_PREFIX = "bcn_"
 IDENTITY_DIR_NAME = "identity"
 KEY_FILE_NAME = "agent.key"
 PBKDF2_ITERATIONS = 600_000
+BIP39_MNEMONIC_PBKDF2_ITERATIONS = 2048
+
+
+def _derive_mnemonic_private_key_seed(
+    phrase: str,
+    *,
+    passphrase: str = "",
+    legacy_sha256: bool = False,
+) -> bytes:
+    """Derive the 32-byte Ed25519 seed from a mnemonic phrase.
+
+    Modern mnemonic-backed identities use the BIP39 seed-stretching step:
+    PBKDF2-HMAC-SHA512 with 2048 iterations and the salt "mnemonic" plus the
+    optional user passphrase.  Older Beacon releases used raw SHA256(phrase);
+    keep that path available only as an explicit recovery mode for legacy
+    identities so restored keys do not silently switch derivation schemes.
+    """
+    normalized_phrase = unicodedata.normalize("NFKD", phrase.strip())
+    if legacy_sha256:
+        return hashlib.sha256(normalized_phrase.encode("utf-8")).digest()
+
+    salt = unicodedata.normalize("NFKD", f"mnemonic{passphrase}").encode("utf-8")
+    seed = hashlib.pbkdf2_hmac(
+        "sha512",
+        normalized_phrase.encode("utf-8"),
+        salt,
+        BIP39_MNEMONIC_PBKDF2_ITERATIONS,
+        dklen=64,
+    )
+    return seed[:32]
 
 
 def _derive_aes_key(password: str, salt: bytes) -> bytes:
@@ -76,7 +107,11 @@ class AgentIdentity:
     # ── Creation ──
 
     @classmethod
-    def generate(cls, use_mnemonic: bool = False) -> "AgentIdentity":
+    def generate(
+        cls,
+        use_mnemonic: bool = False,
+        mnemonic_passphrase: str = "",
+    ) -> "AgentIdentity":
         """Create a new random identity.  Optionally derive from a BIP39 mnemonic."""
         mnemonic_phrase: Optional[str] = None
         if use_mnemonic:
@@ -84,7 +119,10 @@ class AgentIdentity:
                 from mnemonic import Mnemonic  # optional dep
                 m = Mnemonic("english")
                 mnemonic_phrase = m.generate(strength=256)  # 24 words
-                seed = hashlib.sha256(mnemonic_phrase.encode("utf-8")).digest()
+                seed = _derive_mnemonic_private_key_seed(
+                    mnemonic_phrase,
+                    passphrase=mnemonic_passphrase,
+                )
                 sk = Ed25519PrivateKey.from_private_bytes(seed)
                 return cls(sk, mnemonic=mnemonic_phrase)
             except ImportError:
@@ -101,10 +139,25 @@ class AgentIdentity:
         return cls(sk)
 
     @classmethod
-    def from_mnemonic(cls, phrase: str) -> "AgentIdentity":
-        seed = hashlib.sha256(phrase.strip().encode("utf-8")).digest()
+    def from_mnemonic(
+        cls,
+        phrase: str,
+        *,
+        passphrase: str = "",
+        legacy_sha256: bool = False,
+    ) -> "AgentIdentity":
+        seed = _derive_mnemonic_private_key_seed(
+            phrase,
+            passphrase=passphrase,
+            legacy_sha256=legacy_sha256,
+        )
         sk = Ed25519PrivateKey.from_private_bytes(seed)
         return cls(sk, mnemonic=phrase.strip())
+
+    @classmethod
+    def from_legacy_mnemonic(cls, phrase: str) -> "AgentIdentity":
+        """Restore an identity created by pre-BIP39 Beacon releases."""
+        return cls.from_mnemonic(phrase, legacy_sha256=True)
 
     # ── Signing & Verification ──
 

--- a/beacon_skill/transports/rustchain.py
+++ b/beacon_skill/transports/rustchain.py
@@ -15,6 +15,7 @@ from cryptography.hazmat.primitives.kdf.pbkdf2 import PBKDF2HMAC
 from cryptography.hazmat.primitives import hashes
 from cryptography.hazmat.primitives.serialization import Encoding, PrivateFormat, PublicFormat, NoEncryption
 
+from ..identity import _derive_mnemonic_private_key_seed
 from ..retry import with_retry
 
 
@@ -59,7 +60,7 @@ class RustChainKeypair:
         )
 
     @staticmethod
-    def generate_with_mnemonic() -> "RustChainKeypair":
+    def generate_with_mnemonic(mnemonic_passphrase: str = "") -> "RustChainKeypair":
         """Generate a keypair backed by a 24-word BIP39 mnemonic."""
         try:
             from mnemonic import Mnemonic
@@ -67,7 +68,10 @@ class RustChainKeypair:
             raise RuntimeError("mnemonic package required (pip install mnemonic)")
         m = Mnemonic("english")
         phrase = m.generate(strength=256)
-        seed = hashlib.sha256(phrase.encode("utf-8")).digest()
+        seed = _derive_mnemonic_private_key_seed(
+            phrase,
+            passphrase=mnemonic_passphrase,
+        )
         sk = Ed25519PrivateKey.from_private_bytes(seed)
         sk_bytes = sk.private_bytes(Encoding.Raw, PrivateFormat.Raw, NoEncryption())
         pk_bytes = sk.public_key().public_bytes(Encoding.Raw, PublicFormat.Raw)
@@ -79,9 +83,18 @@ class RustChainKeypair:
         )
 
     @staticmethod
-    def from_mnemonic(phrase: str) -> "RustChainKeypair":
+    def from_mnemonic(
+        phrase: str,
+        *,
+        passphrase: str = "",
+        legacy_sha256: bool = False,
+    ) -> "RustChainKeypair":
         """Restore keypair from a 24-word mnemonic."""
-        seed = hashlib.sha256(phrase.strip().encode("utf-8")).digest()
+        seed = _derive_mnemonic_private_key_seed(
+            phrase,
+            passphrase=passphrase,
+            legacy_sha256=legacy_sha256,
+        )
         sk = Ed25519PrivateKey.from_private_bytes(seed)
         sk_bytes = sk.private_bytes(Encoding.Raw, PrivateFormat.Raw, NoEncryption())
         pk_bytes = sk.public_key().public_bytes(Encoding.Raw, PublicFormat.Raw)
@@ -91,6 +104,11 @@ class RustChainKeypair:
             address=_rtc_address_from_public_key_bytes(pk_bytes),
             mnemonic=phrase.strip(),
         )
+
+    @staticmethod
+    def from_legacy_mnemonic(phrase: str) -> "RustChainKeypair":
+        """Restore a keypair created by pre-BIP39 Beacon releases."""
+        return RustChainKeypair.from_mnemonic(phrase, legacy_sha256=True)
 
     @staticmethod
     def from_private_key_hex(private_key_hex: str) -> "RustChainKeypair":

--- a/tests/test_cli_identity_restore.py
+++ b/tests/test_cli_identity_restore.py
@@ -1,0 +1,116 @@
+import argparse
+import contextlib
+import io
+import json
+import os
+import tempfile
+import unittest
+from pathlib import Path
+from typing import Optional, Tuple
+from unittest.mock import patch
+
+from beacon_skill.cli import cmd_identity_restore
+from beacon_skill.identity import AgentIdentity
+
+
+BIP39_TEST_PHRASE = "abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon about"
+
+
+class TestIdentityRestoreCli(unittest.TestCase):
+    def _run_restore(
+        self,
+        *,
+        phrase: str = BIP39_TEST_PHRASE,
+        legacy: bool = False,
+        expect_agent_id: Optional[str] = None,
+        password: Optional[str] = None,
+    ) -> Tuple[int, Optional[dict], str]:
+        args = argparse.Namespace(
+            mnemonic_phrase=phrase,
+            legacy=legacy,
+            expect_agent_id=expect_agent_id,
+            password=password,
+        )
+        stdout = io.StringIO()
+        stderr = io.StringIO()
+        with contextlib.redirect_stdout(stdout), contextlib.redirect_stderr(stderr):
+            rc = cmd_identity_restore(args)
+        raw_stdout = stdout.getvalue().strip()
+        data = json.loads(raw_stdout) if raw_stdout else None
+        return rc, data, stderr.getvalue()
+
+    def test_restore_legacy_flag_preserves_pre_bip39_agent_id(self) -> None:
+        with tempfile.TemporaryDirectory() as td:
+            identity_path = str(Path(td) / "agent.key")
+            with patch.dict(os.environ, {"BEACON_IDENTITY_PATH": identity_path}):
+                rc, data, err = self._run_restore(legacy=True)
+
+        legacy = AgentIdentity.from_legacy_mnemonic(BIP39_TEST_PHRASE)
+        self.assertEqual(rc, 0)
+        self.assertIsNotNone(data)
+        assert data is not None
+        self.assertEqual(data["agent_id"], legacy.agent_id)
+        self.assertEqual(data["derivation"], "legacy_sha256")
+        self.assertIn("pre-BIP39", err)
+
+    def test_restore_expect_agent_id_auto_selects_legacy_match(self) -> None:
+        legacy = AgentIdentity.from_legacy_mnemonic(BIP39_TEST_PHRASE)
+
+        with tempfile.TemporaryDirectory() as td:
+            identity_path = str(Path(td) / "agent.key")
+            with patch.dict(os.environ, {"BEACON_IDENTITY_PATH": identity_path}):
+                rc, data, err = self._run_restore(expect_agent_id=legacy.agent_id)
+
+        self.assertEqual(rc, 0)
+        self.assertIsNotNone(data)
+        assert data is not None
+        self.assertEqual(data["agent_id"], legacy.agent_id)
+        self.assertEqual(data["derivation"], "legacy_sha256")
+        self.assertIn("matched the legacy", err)
+
+    def test_restore_expected_agent_id_mismatch_refuses_to_save(self) -> None:
+        with tempfile.TemporaryDirectory() as td:
+            identity_path = Path(td) / "agent.key"
+            with patch.dict(os.environ, {"BEACON_IDENTITY_PATH": str(identity_path)}):
+                rc, data, err = self._run_restore(expect_agent_id="bcn_deadbeefcafe")
+                self.assertFalse(identity_path.exists())
+
+        self.assertEqual(rc, 1)
+        self.assertIsNone(data)
+        self.assertIn("does not restore", err)
+
+    def test_restore_legacy_flag_still_honors_expected_agent_id(self) -> None:
+        modern = AgentIdentity.from_mnemonic(BIP39_TEST_PHRASE)
+
+        with tempfile.TemporaryDirectory() as td:
+            identity_path = Path(td) / "agent.key"
+            with patch.dict(os.environ, {"BEACON_IDENTITY_PATH": str(identity_path)}):
+                rc, data, err = self._run_restore(
+                    legacy=True,
+                    expect_agent_id=modern.agent_id,
+                )
+                self.assertFalse(identity_path.exists())
+
+        self.assertEqual(rc, 1)
+        self.assertIsNone(data)
+        self.assertIn("does not restore", err)
+
+    def test_restore_auto_keeps_existing_legacy_keystore_agent_id(self) -> None:
+        legacy = AgentIdentity.from_legacy_mnemonic(BIP39_TEST_PHRASE)
+
+        with tempfile.TemporaryDirectory() as td:
+            identity_path = str(Path(td) / "agent.key")
+            with patch.dict(os.environ, {"BEACON_IDENTITY_PATH": identity_path}):
+                legacy.save()
+                rc, data, err = self._run_restore()
+
+        self.assertEqual(rc, 0)
+        self.assertIsNotNone(data)
+        assert data is not None
+        self.assertEqual(data["agent_id"], legacy.agent_id)
+        self.assertEqual(data["derivation"], "legacy_sha256")
+        self.assertIn("existing keystore matches", err)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_identity.py
+++ b/tests/test_identity.py
@@ -1,6 +1,20 @@
+import hashlib
 import unittest
 
 from beacon_skill.identity import AgentIdentity, agent_id_from_pubkey
+
+BIP39_TEST_PHRASE = "abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon about"
+
+
+def _expected_bip39_seed_hex(phrase: str, passphrase: str = "") -> str:
+    seed = hashlib.pbkdf2_hmac(
+        "sha512",
+        phrase.encode("utf-8"),
+        f"mnemonic{passphrase}".encode("utf-8"),
+        2048,
+        dklen=64,
+    )
+    return seed[:32].hex()
 
 
 class TestAgentIdentity(unittest.TestCase):
@@ -45,6 +59,47 @@ class TestAgentIdentity(unittest.TestCase):
         b = AgentIdentity.from_mnemonic(a.mnemonic)
         self.assertEqual(a.agent_id, b.agent_id)
         self.assertEqual(a.public_key_hex, b.public_key_hex)
+
+    def test_mnemonic_derivation_uses_bip39_pbkdf2(self) -> None:
+        ident = AgentIdentity.from_mnemonic(BIP39_TEST_PHRASE)
+        raw_sha256_seed = hashlib.sha256(BIP39_TEST_PHRASE.encode("utf-8")).hexdigest()
+
+        self.assertEqual(
+            ident.private_key_hex,
+            _expected_bip39_seed_hex(BIP39_TEST_PHRASE),
+        )
+        self.assertNotEqual(ident.private_key_hex, raw_sha256_seed)
+
+    def test_mnemonic_passphrase_changes_identity(self) -> None:
+        plain = AgentIdentity.from_mnemonic(BIP39_TEST_PHRASE)
+        protected = AgentIdentity.from_mnemonic(
+            BIP39_TEST_PHRASE,
+            passphrase="correct horse battery staple",
+        )
+
+        self.assertEqual(
+            protected.private_key_hex,
+            _expected_bip39_seed_hex(
+                BIP39_TEST_PHRASE,
+                "correct horse battery staple",
+            ),
+        )
+        self.assertNotEqual(plain.agent_id, protected.agent_id)
+
+    def test_legacy_mnemonic_requires_explicit_opt_in(self) -> None:
+        legacy = AgentIdentity.from_legacy_mnemonic(BIP39_TEST_PHRASE)
+        legacy_flag = AgentIdentity.from_mnemonic(
+            BIP39_TEST_PHRASE,
+            legacy_sha256=True,
+        )
+        modern = AgentIdentity.from_mnemonic(BIP39_TEST_PHRASE)
+
+        self.assertEqual(
+            legacy.private_key_hex,
+            hashlib.sha256(BIP39_TEST_PHRASE.encode("utf-8")).hexdigest(),
+        )
+        self.assertEqual(legacy.agent_id, legacy_flag.agent_id)
+        self.assertNotEqual(legacy.agent_id, modern.agent_id)
 
     def test_encrypted_keystore_roundtrip(self) -> None:
         ident = AgentIdentity.generate()

--- a/tests/test_rustchain.py
+++ b/tests/test_rustchain.py
@@ -1,7 +1,21 @@
+import hashlib
 import json
 import unittest
 
 from beacon_skill.transports.rustchain import RustChainClient, RustChainKeypair
+
+BIP39_TEST_PHRASE = "abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon about"
+
+
+def _expected_bip39_seed_hex(phrase: str, passphrase: str = "") -> str:
+    seed = hashlib.pbkdf2_hmac(
+        "sha512",
+        phrase.encode("utf-8"),
+        f"mnemonic{passphrase}".encode("utf-8"),
+        2048,
+        dklen=64,
+    )
+    return seed[:32].hex()
 
 
 class TestRustChainSigning(unittest.TestCase):
@@ -33,6 +47,47 @@ class TestRustChainSigning(unittest.TestCase):
         kp2 = RustChainKeypair.from_mnemonic(kp1.mnemonic)
         self.assertEqual(kp1.address, kp2.address)
         self.assertEqual(kp1.private_key_hex, kp2.private_key_hex)
+
+    def test_mnemonic_derivation_uses_bip39_pbkdf2(self) -> None:
+        kp = RustChainKeypair.from_mnemonic(BIP39_TEST_PHRASE)
+        raw_sha256_seed = hashlib.sha256(BIP39_TEST_PHRASE.encode("utf-8")).hexdigest()
+
+        self.assertEqual(
+            kp.private_key_hex,
+            _expected_bip39_seed_hex(BIP39_TEST_PHRASE),
+        )
+        self.assertNotEqual(kp.private_key_hex, raw_sha256_seed)
+
+    def test_mnemonic_passphrase_changes_keypair(self) -> None:
+        plain = RustChainKeypair.from_mnemonic(BIP39_TEST_PHRASE)
+        protected = RustChainKeypair.from_mnemonic(
+            BIP39_TEST_PHRASE,
+            passphrase="correct horse battery staple",
+        )
+
+        self.assertEqual(
+            protected.private_key_hex,
+            _expected_bip39_seed_hex(
+                BIP39_TEST_PHRASE,
+                "correct horse battery staple",
+            ),
+        )
+        self.assertNotEqual(plain.address, protected.address)
+
+    def test_legacy_mnemonic_requires_explicit_opt_in(self) -> None:
+        legacy = RustChainKeypair.from_legacy_mnemonic(BIP39_TEST_PHRASE)
+        legacy_flag = RustChainKeypair.from_mnemonic(
+            BIP39_TEST_PHRASE,
+            legacy_sha256=True,
+        )
+        modern = RustChainKeypair.from_mnemonic(BIP39_TEST_PHRASE)
+
+        self.assertEqual(
+            legacy.private_key_hex,
+            hashlib.sha256(BIP39_TEST_PHRASE.encode("utf-8")).hexdigest(),
+        )
+        self.assertEqual(legacy.address, legacy_flag.address)
+        self.assertNotEqual(legacy.address, modern.address)
 
     def test_encrypted_keystore(self) -> None:
         kp = RustChainKeypair.generate()


### PR DESCRIPTION
## Summary
Addresses the remaining L1 item from Scottcjn/beacon-skill#862: mnemonic-backed Beacon identities and the RustChain transport wallet restored Ed25519 seeds with raw `SHA256(phrase)`.

This PR:
- derives modern mnemonic-backed identities with the BIP39 seed-stretching step: PBKDF2-HMAC-SHA512, 2048 iterations, salt `mnemonic` + optional passphrase
- uses the first 32 bytes of the BIP39 seed as the Ed25519 private seed for both `AgentIdentity` and `RustChainKeypair`
- adds passphrase support for restores/generation
- keeps pre-BIP39 recovery explicit via `legacy_sha256=True` and `from_legacy_mnemonic()` so old agents can still recover their historical key intentionally
- adds regression tests proving modern derivation is not the old raw SHA256 path and that legacy restore is opt-in

## Why this shape
Changing mnemonic derivation is compatibility-sensitive. Defaulting new/restored mnemonics to PBKDF2 fixes the weak-KDF issue, while the explicit legacy path avoids stranding existing agents that must recover an identity created by older Beacon releases.

## Testing
- `uv run --no-project --with pytest --with cryptography --with requests --with mnemonic python -m pytest -q tests\test_identity.py tests\test_rustchain.py` -> 15 passed
- `uv run --no-project --with pytest --with cryptography --with requests --with mnemonic --with pynacl python -m pytest -q tests\test_identity.py tests\test_rustchain.py tests\test_codec.py tests\test_core_integration.py` -> 57 passed
- `uv run --no-project --with cryptography --with requests python -m py_compile beacon_skill\identity.py beacon_skill\transports\rustchain.py tests\test_identity.py tests\test_rustchain.py` -> passed
- `git diff --check` -> passed (Windows CRLF warnings only)

RTC payout wallet for any accepted security/bug bounty credit: `RTC973498f72747cd1637e395521319c0ad61c0f68c`