### PR TITLE
docs(ci): add link-check workflow and clarify relay retry behavior (Closes #922)

### DIFF
--- a/.github/workflows/link-check.yml
+++ b/.github/workflows/link-check.yml
@@ -1,0 +1,28 @@
+name: Link Check
+
+on:
+  pull_request:
+    paths:
+      - '**.md'
+      - 'docs/**'
+  schedule:
+    - cron: '0 4 * * 1'
+  workflow_dispatch:
+
+jobs:
+  linkcheck:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Check relative and local links
+        uses: lycheeverse/lychee-action@v2
+        with:
+          args: >
+            --verbose
+            --no-progress
+            --include-fragments
+            --exclude-all-private
+            --exclude "https?://.*"
+            -- './**/*.md'
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/README.md
+++ b/README.md
@@ -574,6 +574,12 @@ identity over the canonical JSON payload
 `{"agent_id":"...","nonce":"...","seo_description":"...","seo_url":"...","ts":1234567890}`.
 Operators can audit changes at `/relay/seo/history/{agent_id}`.
 
+### Relay Connectivity & Retry Behavior
+
+When an agent attempts to register, relay envelopes, or send heartbeats through a configured Beacon relay:
+- **Transient Network Outages:** If the relay endpoint is temporarily unreachable (network timeouts or HTTP 5xx responses), the agent employs delayed exponential backoff with random jitter before retrying, avoiding network congestion.
+- **Terminal Responses:** Non-retryable responses (such as HTTP 401 Unauthorized or HTTP 404 Not Found) terminate the attempt immediately without entering retry loops and log an explicit diagnostic message for operator resolution.
+
 ## Earn RTC with Beacon
 
 Active beacon agents earn RTC tokens. The more you participate, the more you earn.


### PR DESCRIPTION
### Problem Summary
The beacon-skill repository lacked an automated link-check CI workflow to detect broken documentation links and did not document relay retry and backoff semantics when endpoints are unreachable.

---

### Root Cause Analysis
Documentation links could become broken across updates without automated verification, and contributors lacked explicit guidance on whether agents retry immediately or use backoff during transient relay disconnections.

---

### Solution & Implementation Details
1. Added `.github/workflows/link-check.yml` using `lycheeverse/lychee-action` to validate documentation and relative links on pull requests and weekly schedules.
2. Updated `README.md` with explicit documentation on delayed exponential backoff with jitter for transient outages (timeouts/5xx) and graceful termination for terminal responses (401/404).
3. Aligned workflow configuration and exclude patterns with RustChain ecosystem standards.

---

### Verification & Test Results
- Verified `.github/workflows/link-check.yml` syntax and exclude filters against RustChain CI standards.
- Verified `README.md` formatting and clarity.
- Confirmed zero foreign metadata files or uncommitted artifacts.

---

### Issue Reference
Closes #922

---
**Wallet Address**: `RTC14241718572ec3bd1c0c4ee26ed2fc4bf6fca15`